### PR TITLE
feat/add-cli

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-ANTHROPIC_API_KEY="..."
+ANTHROPIC_API_KEY="api key here"
+OPENAI_API_KEY="api key here"

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ cython_debug/
 #.idea/
 
 .DS_Store
+
+# local files
+plan.md
+.python-version

--- a/README.md
+++ b/README.md
@@ -60,22 +60,88 @@ For more information visit the [ARC Prize](https://arcprize.org/).
 ### CLI Usage
 
 #### Validation
-The CLI tool provides validation for model outputs against task sets. To validate a model's outputs:
-
+Validate model outputs against task sets:
 ```bash
-python cli/main.py validate <task_directory> <output_directory>
+# Basic validation
+python cli/main.py validate data/arc-agi/data/evaluation submissions/open_ai_o1_high_20241217
+
+# Validate another model's outputs
+python cli/main.py validate data/arc-agi/data/evaluation submissions/claude_sonnet_20241022
+```
+
+#### Upload
+Upload a single model's outputs to a task set repository:
+```bash
+# Basic upload (private repository)
+python cli/main.py upload submissions/open_ai_o1_high_20241217 --task-set public_eval_v1
+
+# Upload to a different organization
+python cli/main.py upload submissions/claude_sonnet_20241022 --task-set public_eval_v1 --org your-org-name
+
+# Create a public repository
+python cli/main.py upload submissions/deepseek_v3 --task-set public_eval_v1 --public
+```
+
+#### Bulk Upload
+Upload multiple model outputs at once:
+```bash
+# Upload all models in submissions directory (private repository)
+python cli/main.py bulk-upload submissions/ --task-set public_eval_v1
+
+# Upload to a different organization
+python cli/main.py bulk-upload submissions/ --task-set public_eval_v1 --org your-org-name
+
+# Create a public repository
+python cli/main.py bulk-upload submissions/ --task-set public_eval_v1 --public
+```
+
+Notes:
+- All uploads create private repositories by default
+- Use `--public` flag to create public repositories
+- Files are uploaded to subdirectories matching model names
+- Default organization is "arcprize"
+
+### Hugging Face Upload
+
+#### Authentication
+Before uploading, you'll need to authenticate with Hugging Face:
+
+1. Get your access token from https://huggingface.co/settings/tokens
+2. Set up authentication using either method:
+   ```bash
+   # Option 1: Environment variable
+   export HUGGING_FACE_HUB_TOKEN=your_token_here
+   
+   # Option 2: CLI login
+   huggingface-cli login
+   ```
+
+#### Upload
+The upload process organizes submissions by task sets. Each task set (e.g., public_eval_v1) becomes a separate dataset repository on Hugging Face, with model submissions organized in subdirectories.
+
+Structure:
+```
+task_set_name/
+├── model_name_1/
+│   ├── result1.json
+│   ├── result2.json
+├── model_name_2/
+│   ├── result1.json
+│   └── result2.json
+```
+
+To upload model outputs:
+```bash
+python cli/main.py upload submissions/model_name --task-set task_set_name [--org organization] [--public]
 ```
 
 For example:
 ```bash
-python cli/main.py validate data/arc-agi/data/evaluation submissions/open_ai_o1_high_20241217
+python cli/main.py upload submissions/open_ai_o1_high_20241217 --task-set public_eval_v1
 ```
 
-The validator will:
-1. Count JSON files in both directories
-2. Verify the output directory has the same number of files as the task directory
-3. Validate that all output files contain valid JSON
-
-The command will return:
-- ✅ Success if file counts match and all JSON is valid
-- ❌ Error if counts mismatch or invalid JSON is found
+#### Bulk Upload
+To upload multiple model outputs at once:
+```bash
+python cli/main.py bulk-upload submissions/ --task-set task_set_name [--org organization] [--public]
+```

--- a/README.md
+++ b/README.md
@@ -56,3 +56,26 @@ Specifically, we would love help adding more model adapters to the `src/adapters
 More will get added by the ARC-AGI team, but we'll also gladly accept contributions from the community.
 
 For more information visit the [ARC Prize](https://arcprize.org/).
+
+### CLI Usage
+
+#### Validation
+The CLI tool provides validation for model outputs against task sets. To validate a model's outputs:
+
+```bash
+python cli/main.py validate <task_directory> <output_directory>
+```
+
+For example:
+```bash
+python cli/main.py validate data/arc-agi/data/evaluation submissions/open_ai_o1_high_20241217
+```
+
+The validator will:
+1. Count JSON files in both directories
+2. Verify the output directory has the same number of files as the task directory
+3. Validate that all output files contain valid JSON
+
+The command will return:
+- ✅ Success if file counts match and all JSON is valid
+- ❌ Error if counts mismatch or invalid JSON is found

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,7 +1,10 @@
+#!/usr/bin/env python3
+
 import click
 import json
 import os
 from pathlib import Path
+from huggingface_hub import HfApi
 
 def validate_json_structure(content):
     """Validate the JSON can be parsed."""
@@ -62,39 +65,100 @@ def validate(task_dir, output_dir):
     return is_valid
 
 @cli.command()
-@click.argument('model_dir', type=click.Path(exists=True))
-def upload(model_dir):
-    """Upload JSON files to Hugging Face dataset."""
+@click.argument('output_dir', type=click.Path(exists=True))
+@click.option('--task-set', type=str, required=True, help="Name of task set (e.g. public_eval_v1)")
+@click.option('--org', type=str, default="arcprize", help="Hugging Face organization name")
+@click.option('--public/--private', default=False, help="Make dataset public (default: private)")
+def upload(output_dir, task_set, org, public):
+    """Upload model outputs to Hugging Face dataset."""
     click.echo(f"Starting upload...")
     
-    path = Path(model_dir)
-    model_name = path.name
+    output_path = Path(output_dir)
+    model_name = output_path.name
+    
+    # Format repo name based on task set and org
+    repo_id = f"{org}/{task_set}"
     
     api = HfApi()
-    repo_id = f"renee-evals/{model_name}"
-    
     try:
-        # Create or get dataset repository
-        api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True)
+        # Create or get dataset repository for this task set
+        api.create_repo(
+            repo_id=repo_id, 
+            repo_type="dataset",
+            private=not public,  # Set privacy based on flag
+            exist_ok=True
+        )
         
-        # Upload all JSON files
-        files = list(path.glob('*.json'))
-        click.echo(f"Uploading {len(files)} files to {repo_id}...")
+        click.echo(f"Created/updated repository as {'public' if public else 'private'}")
         
-        for file in files:
-            api.upload_file(
-                path_or_fileobj=str(file),
-                path_in_repo=file.name,
-                repo_id=repo_id,
-                repo_type="dataset"
-            )
-            click.echo(f"Uploaded {file.name}")
+        # Upload files to a model-specific folder within the task set repo
+        click.echo(f"Uploading files to {repo_id}/{model_name}...")
+        
+        api.upload_folder(
+            folder_path=str(output_path),
+            path_in_repo=model_name,  # Places files in task_set/model_name/
+            repo_id=repo_id,
+            repo_type="dataset"
+        )
             
-        click.echo(f"\n✅ Successfully uploaded all files to {repo_id}")
+        click.echo(f"\n✅ Successfully uploaded files to {repo_id}/{model_name}")
         return True
         
     except Exception as e:
         click.echo(f"\n❌ Upload failed: {str(e)}")
+        return False
+
+@cli.command(name='bulk-upload')
+@click.argument('submissions_dir', type=click.Path(exists=True))
+@click.option('--task-set', type=str, required=True, help="Name of task set (e.g. public_eval_v1)")
+@click.option('--org', type=str, default="arcprize", help="Hugging Face organization name")
+@click.option('--public/--private', default=False, help="Make dataset public (default: private)")
+def bulk_upload(submissions_dir, task_set, org, public):
+    """Upload all model outputs from a submissions directory to Hugging Face."""
+    click.echo(f"Starting bulk upload...")
+    
+    submissions_path = Path(submissions_dir)
+    repo_id = f"{org}/{task_set}"
+    
+    # Get all model directories
+    model_dirs = [d for d in submissions_path.iterdir() if d.is_dir()]
+    click.echo(f"Found {len(model_dirs)} model directories")
+    
+    api = HfApi()
+    try:
+        # Create or get dataset repository
+        api.create_repo(
+            repo_id=repo_id, 
+            repo_type="dataset",
+            private=not public,
+            exist_ok=True
+        )
+        
+        click.echo(f"Created/updated repository as {'public' if public else 'private'}")
+        
+        # Upload each model's files
+        success_count = 0
+        for model_dir in model_dirs:
+            model_name = model_dir.name
+            click.echo(f"\nUploading {model_name} to {repo_id}/{model_name}...")
+            
+            try:
+                api.upload_folder(
+                    folder_path=str(model_dir),
+                    path_in_repo=model_name,
+                    repo_id=repo_id,
+                    repo_type="dataset"
+                )
+                click.echo(f"✅ Successfully uploaded {model_name}")
+                success_count += 1
+            except Exception as e:
+                click.echo(f"❌ Failed to upload {model_name}: {str(e)}")
+        
+        click.echo(f"\nBulk upload complete: {success_count}/{len(model_dirs)} models uploaded successfully")
+        return success_count == len(model_dirs)
+        
+    except Exception as e:
+        click.echo(f"\n❌ Bulk upload failed: {str(e)}")
         return False
 
 if __name__ == '__main__':

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,54 @@
+import click
+import json
+import os
+from pathlib import Path
+
+def validate_json_structure(content):
+    """Validate the JSON can be parsed."""
+    return True  # If we got here, json.load() succeeded
+
+@click.group()
+def cli():
+    """CLI tool for validating and uploading model submissions."""
+    pass
+
+@cli.command()
+@click.argument('model_dir', type=click.Path(exists=True))
+def validate(model_dir):
+    """Validate JSON files in the model directory."""
+    click.echo(f"Starting validation...")
+    
+    path = Path(model_dir)
+    click.echo(f"Checking directory: {path.absolute()}")
+    
+    files = list(path.glob('*.json'))
+    
+    click.echo(f"\nValidating {path.name}...")
+    click.echo(f"Found {len(files)} files (expected 100)")
+    
+    is_valid = True
+    
+    if len(files) != 100:
+        click.echo("❌ Error: Directory must contain exactly 100 files")
+        is_valid = False
+    
+    invalid_files = []
+    for file in files:
+        try:
+            with open(file) as f:
+                json.load(f)  # Just try to parse it
+        except json.JSONDecodeError:
+            invalid_files.append(file.name)
+            
+    if invalid_files:
+        click.echo("\n❌ The following files have invalid JSON:")
+        for file in invalid_files:
+            click.echo(f"  - {file}")
+        is_valid = False
+    else:
+        click.echo("\n✅ All files contain valid JSON")
+
+    return is_valid
+
+if __name__ == '__main__':
+    cli() 

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,30 +13,41 @@ def cli():
     pass
 
 @cli.command()
-@click.argument('model_dir', type=click.Path(exists=True))
-def validate(model_dir):
-    """Validate JSON files in the model directory."""
+@click.argument('task_dir', type=click.Path(exists=True))
+@click.argument('output_dir', type=click.Path(exists=True))
+def validate(task_dir, output_dir):
+    """Validate output files against task directory."""
     click.echo(f"Starting validation...")
     
-    path = Path(model_dir)
-    click.echo(f"Checking directory: {path.absolute()}")
+    task_path = Path(task_dir)
+    output_path = Path(output_dir)
     
-    files = list(path.glob('*.json'))
+    click.echo(f"Task directory: {task_path.absolute()}")
+    click.echo(f"Output directory: {output_path.absolute()}")
     
-    click.echo(f"\nValidating {path.name}...")
-    click.echo(f"Found {len(files)} files (expected 100)")
+    # Count JSON files in task directory
+    task_files = list(task_path.glob('*.json'))
+    expected_count = len(task_files)
     
-    is_valid = True
+    # Count and validate output files
+    output_files = list(output_path.glob('*.json'))
     
-    if len(files) != 100:
-        click.echo("❌ Error: Directory must contain exactly 100 files")
+    click.echo(f"\nValidating {output_path.name}...")
+    click.echo(f"Found {len(output_files)} files (expected {expected_count})")
+    
+    
+    if len(output_files) != expected_count:
+        click.echo(f"❌ Error: Output directory must contain exactly {expected_count} files (found in {task_dir})")
         is_valid = False
+    else:
+        click.echo(f"✅ Output directory contains {expected_count} files")
+        is_valid = True
     
     invalid_files = []
-    for file in files:
+    for file in output_files:
         try:
             with open(file) as f:
-                json.load(f)  # Just try to parse it
+                json.load(f)
         except json.JSONDecodeError:
             invalid_files.append(file.name)
             
@@ -49,6 +60,42 @@ def validate(model_dir):
         click.echo("\n✅ All files contain valid JSON")
 
     return is_valid
+
+@cli.command()
+@click.argument('model_dir', type=click.Path(exists=True))
+def upload(model_dir):
+    """Upload JSON files to Hugging Face dataset."""
+    click.echo(f"Starting upload...")
+    
+    path = Path(model_dir)
+    model_name = path.name
+    
+    api = HfApi()
+    repo_id = f"renee-evals/{model_name}"
+    
+    try:
+        # Create or get dataset repository
+        api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True)
+        
+        # Upload all JSON files
+        files = list(path.glob('*.json'))
+        click.echo(f"Uploading {len(files)} files to {repo_id}...")
+        
+        for file in files:
+            api.upload_file(
+                path_or_fileobj=str(file),
+                path_in_repo=file.name,
+                repo_id=repo_id,
+                repo_type="dataset"
+            )
+            click.echo(f"Uploaded {file.name}")
+            
+        click.echo(f"\n✅ Successfully uploaded all files to {repo_id}")
+        return True
+        
+    except Exception as e:
+        click.echo(f"\n❌ Upload failed: {str(e)}")
+        return False
 
 if __name__ == '__main__':
     cli() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ tqdm==4.66.5
 typing_extensions==4.12.2
 urllib3==2.2.3
 openai==1.58.1
+click>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fsspec==2024.10.0
 h11==0.14.0
 httpcore==1.0.6
 httpx==0.27.2
-huggingface-hub==0.26.1
+huggingface-hub>=0.26.1
 idna==3.10
 jiter==0.6.1
 packaging==24.1


### PR DESCRIPTION
feat: add CLI for validation and model submission uploads  

- Implemented `cli/main.py` with commands for validating and uploading model outputs  
- Extended `.gitignore` to include `plan.md` and `.python-version`  
- Updated `README.md` with CLI usage instructions for validation and uploads  
- Modified `requirements.txt` to include `click>=8.0.0` and relaxed `huggingface-hub` version constraint