### PR TITLE
fixes choices and anthropic kwargs bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,7 +142,16 @@ class ARCTester:
 
         try:
             # Parse the answer field but keep the full attempt object
-            parsed_answer = self.parse_and_validate_json(attempt.metadata.choices[0].message.content)
+            # Always use the last choice in the array (which should be the assistant's response)
+            if attempt.metadata.choices:
+                last_choice = attempt.metadata.choices[-1]
+                if last_choice.message.content:
+                    parsed_answer = self.parse_and_validate_json(last_choice.message.content)
+                else:
+                    raise ValueError("Assistant response is empty")
+            else:
+                raise ValueError("No choices found in response")
+            
             # Update the answer in the original attempt - now accepts List[List[int]]
             attempt.answer = parsed_answer
             return attempt

--- a/src/adapters/anthropic.py
+++ b/src/adapters/anthropic.py
@@ -113,15 +113,12 @@ class AnthropicAdapter(ProviderAdapter):
         """
         Make a raw API call to Anthropic and return the response
         """
-        max_tokens = self.model_config.kwargs.get('max_tokens', 4096)  # Get from config or use default
-        temperature = self.model_config.kwargs.get('temperature', 0.0)  # Get from config or use default
         
         return self.client.messages.create(
             model=self.model_config.model_name,
-            max_tokens=max_tokens,
-            temperature=temperature,
             messages=messages,
-            tools=tools
+            tools=tools,
+            **self.model_config.kwargs
         )
     
     def extract_json_from_response(self, input_response: str) -> List[List[int]]:


### PR DESCRIPTION
fix: improve response parsing and adapter config handling

- Ensured `ARCTester` correctly retrieves and validates the last model response.
- Removed redundant parameter extraction in `AnthropicAdapter`, using `**self.model_config.kwargs` instead.
- Improved error handling for cases where no model response is available.