### PR TITLE
Ensure verbosity: high for Responses API reasoning models

### DIFF
--- a/src/arc_agi_benchmarking/adapters/openai_base.py
+++ b/src/arc_agi_benchmarking/adapters/openai_base.py
@@ -165,11 +165,22 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         Delete a response from the OpenAI API
         """
         self.client.responses.delete(response_id)
-    
+
+    def _ensure_verbosity(self) -> None:
+        """
+        Ensure verbosity is set to 'high' for Responses API calls unless explicitly configured.
+        This ensures reasoning models return detailed reasoning logs.
+        """
+        if 'text' not in self.model_config.kwargs:
+            self.model_config.kwargs['text'] = {'verbosity': 'high'}
+        elif 'verbosity' not in self.model_config.kwargs['text']:
+            self.model_config.kwargs['text']['verbosity'] = 'high'
+
     def _responses(self, messages: List[Dict[str, str]]) -> Any:
         """
         Make a call to the OpenAI Responses API
         """
+        self._ensure_verbosity()
 
         resp = self.client.responses.create(
             model=self.model_config.model_name,
@@ -198,7 +209,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         Make a streaming call to the OpenAI Responses API and return the final response.
         """
         logger.debug(f"Starting streaming responses for model: {self.model_config.model_name}")
-        
+
+        self._ensure_verbosity()
+
         # Prepare kwargs for streaming, removing 'stream' to avoid duplication
         stream_kwargs = {k: v for k, v in self.model_config.kwargs.items() if k != 'stream'}
         


### PR DESCRIPTION
# Problem: As seen in the recent GPT5.1 test there were no reasoning logs surfaced.  

- This can be seen in https://huggingface.co/datasets/arcprize/arc_agi_v2_public_eval/blob/main/gpt-5-1-2025-11-13-thinking-high/0934a4d8.json despite everything seemingly set correctly to capture it, only the word `detailed` was returned.  From my own experiences with the Responses API and reasoning traces, I have found that frequently reasoning text will not be returned unless the verbosity parameter is set to high.  

Add _ensure_verbosity() helper that automatically sets text.verbosity to "high" for Responses API calls unless explicitly configured. This ensures GPT-5/o-series reasoning models return detailed reasoning logs.

