### PR TITLE
Centralize load_dotenv() to entry points only

### DIFF
--- a/cli/run_all.py
+++ b/cli/run_all.py
@@ -10,6 +10,9 @@ import contextvars
 import sys
 import logging
 
+from dotenv import load_dotenv
+load_dotenv()
+
 # Add the project root directory and the src directory to sys.path
 # This allows cli/run_all.py to import 'main' and 'src' from the project root
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/src/arc_agi_benchmarking/adapters/anthropic.py
+++ b/src/arc_agi_benchmarking/adapters/anthropic.py
@@ -2,13 +2,10 @@ from .provider import ProviderAdapter
 from arc_agi_benchmarking.schemas import ARCTaskOutput, AttemptMetadata, Choice, Message, Usage, Cost, CompletionTokensDetails, Attempt
 import anthropic
 import os
-from dotenv import load_dotenv
 import json
 from typing import List, Optional, Any
 from datetime import datetime, timezone
 import logging
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
+++ b/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
@@ -1,14 +1,11 @@
 from .provider import ProviderAdapter
 from arc_agi_benchmarking.schemas import AttemptMetadata, Choice, Message, Usage, Cost, CompletionTokensDetails, PromptTokensDetails, Attempt, ToolCall
 import os
-from dotenv import load_dotenv
 import json
 from typing import List, Optional, Any
 from datetime import datetime, timezone
 import logging
 import asyncio
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/arc_agi_benchmarking/adapters/codexcli.py
+++ b/src/arc_agi_benchmarking/adapters/codexcli.py
@@ -10,7 +10,6 @@ from arc_agi_benchmarking.schemas import (
     Attempt,
     ToolCall,
 )
-from dotenv import load_dotenv
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timezone
 import subprocess
@@ -18,8 +17,6 @@ import logging
 import json
 import os
 import shutil
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/arc_agi_benchmarking/adapters/deepseek.py
+++ b/src/arc_agi_benchmarking/adapters/deepseek.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -10,7 +9,6 @@ from typing import Optional, Any, List, Dict
 from .openai_base import OpenAIBaseAdapter
 import re
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class DeepseekAdapter(OpenAIBaseAdapter): # Inherit from OpenAIBaseAdapter

--- a/src/arc_agi_benchmarking/adapters/fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/fireworks.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -12,7 +11,6 @@ import re
 # Import the base class we will now inherit from
 from .openai_base import OpenAIBaseAdapter
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class FireworksAdapter(OpenAIBaseAdapter): # Inherit from OpenAIBaseAdapter

--- a/src/arc_agi_benchmarking/adapters/gemini.py
+++ b/src/arc_agi_benchmarking/adapters/gemini.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from google import genai
 from google.genai import types
@@ -9,7 +8,6 @@ from datetime import datetime, timezone
 from arc_agi_benchmarking.schemas import ARCTaskOutput, AttemptMetadata, Choice, Message, Usage, Cost, CompletionTokensDetails, Attempt
 import logging
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class _StreamResponse:

--- a/src/arc_agi_benchmarking/adapters/grok.py
+++ b/src/arc_agi_benchmarking/adapters/grok.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -12,7 +11,6 @@ import re
 # Import the base class
 from .openai_base import OpenAIBaseAdapter
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class GrokAdapter(OpenAIBaseAdapter):

--- a/src/arc_agi_benchmarking/adapters/groq.py
+++ b/src/arc_agi_benchmarking/adapters/groq.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -12,7 +11,6 @@ import re
 # Import the base class we will now inherit from
 from .openai_base import OpenAIBaseAdapter
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class GroqAdapter(OpenAIBaseAdapter): # Inherit from OpenAIBaseAdapter

--- a/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from huggingface_hub import InferenceClient
 from datetime import datetime
@@ -8,7 +7,6 @@ from arc_agi_benchmarking.schemas import ARCTaskOutput, AttemptMetadata, Choice,
 import logging
 from typing import Optional
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class HuggingFaceFireworksAdapter(ProviderAdapter):

--- a/src/arc_agi_benchmarking/adapters/open_ai.py
+++ b/src/arc_agi_benchmarking/adapters/open_ai.py
@@ -1,7 +1,6 @@
 from .provider import ProviderAdapter
 from .openai_base import OpenAIBaseAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -9,8 +8,6 @@ from arc_agi_benchmarking.schemas import APIType, AttemptMetadata, Choice, Messa
 from typing import Optional, Any, List, Dict
 
 import re
-
-load_dotenv()
 
 
 class OpenAIAdapter(OpenAIBaseAdapter):

--- a/src/arc_agi_benchmarking/adapters/openai_base.py
+++ b/src/arc_agi_benchmarking/adapters/openai_base.py
@@ -1,6 +1,5 @@
 import abc
 from .provider import ProviderAdapter
-from dotenv import load_dotenv
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice as OpenAIChoice
 from openai.types import CompletionUsage
@@ -10,8 +9,6 @@ from typing import Optional, Any, List, Dict
 from time import sleep
 import logging
 import time
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/arc_agi_benchmarking/adapters/openrouter.py
+++ b/src/arc_agi_benchmarking/adapters/openrouter.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -12,7 +11,6 @@ import re
 # Import the base class
 from .openai_base import OpenAIBaseAdapter
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class OpenRouterAdapter(OpenAIBaseAdapter):

--- a/src/arc_agi_benchmarking/adapters/xai.py
+++ b/src/arc_agi_benchmarking/adapters/xai.py
@@ -1,6 +1,5 @@
 from .provider import ProviderAdapter
 import os
-from dotenv import load_dotenv
 import json
 from openai import OpenAI
 from datetime import datetime, timezone
@@ -13,7 +12,6 @@ import httpx
 # Import the base class
 from .openai_base import OpenAIBaseAdapter
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 class XAIAdapter(OpenAIBaseAdapter):


### PR DESCRIPTION
## Summary
- Remove redundant load_dotenv() calls from 13 adapter files
- Add missing load_dotenv() to cli/run_all.py (was a bug)
- Keep load_dotenv() only in entry points: main.py, cli/run_all.py, cli/submission_cli.py

## Test plan
- [x] All 201 tests pass
- [x] Single task run verified with random-baseline
- [x] Batch run verified with random-baseline