### PR TITLE
Fix RuntimeWarning when running scoring module

### DIFF
--- a/src/arc_agi_benchmarking/scoring/__main__.py
+++ b/src/arc_agi_benchmarking/scoring/__main__.py
@@ -1,0 +1,4 @@
+from arc_agi_benchmarking.scoring.scoring import main
+
+if __name__ == "__main__":
+    main()

--- a/src/arc_agi_benchmarking/scoring/scoring.py
+++ b/src/arc_agi_benchmarking/scoring/scoring.py
@@ -246,7 +246,7 @@ class ARCScorer:
 
         return total_score, total_tasks
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="Run ARC Tester")
 
     parser.add_argument("--task_dir", type=str, help="Task directory which contains the full tasks (including solutions)")
@@ -264,3 +264,7 @@ if __name__ == "__main__":
     )
 
     arc_scorer.score_submission()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds __main__.py so the scoring package can be invoked directly without the module import warning.