### PR TITLE
Add Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow for Claude Code bot integration.

When merged, team members can:
- Mention `@claude` in issues/PRs to ask questions
- Request code reviews with `@claude review this`
- Ask for implementations with `@claude implement X`

## Setup Required
After merging, add `ANTHROPIC_API_KEY` to repo secrets:
1. Go to Settings > Secrets and variables > Actions
2. Add new secret: `ANTHROPIC_API_KEY`

## References
- [Claude Code GitHub Actions docs](https://code.claude.com/docs/en/github-actions)
- [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)

## Test plan
- [x] Workflow YAML syntax valid
- [ ] Add ANTHROPIC_API_KEY secret after merge
- [ ] Test @claude mention in a PR comment