### PR TITLE
Add dataset access control for model configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,10 @@ analyze_submission_times.py
 /test_logs/*
 .codex_*
 dummy_submissions
+
+data/public-v1
+data/public-v2
+data/semi-private-v1
+data/semi-private-v2
+data/private-v1
+data/private-v2

--- a/cli/check_dataset.py
+++ b/cli/check_dataset.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Check if a model configuration is allowed to run on a specific dataset.
+
+Usage:
+    python cli/check_dataset.py <config_name> <data_source>
+
+Exit codes:
+    0 - Dataset is allowed
+    1 - Dataset is NOT allowed
+    2 - Configuration not found or other error
+
+Examples:
+    python cli/check_dataset.py claude-3-5-sonnet-20241022 public-v2/evaluation
+    python cli/check_dataset.py qwen3-max private-v1/evaluation  # Will exit 1
+"""
+import sys
+import os
+
+# Add project root to path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from arc_agi_benchmarking.utils.task_utils import (
+    get_allowed_datasets,
+    is_dataset_allowed,
+)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: check_dataset.py <config_name> <data_source>", file=sys.stderr)
+        print("Example: check_dataset.py claude-3-5-sonnet-20241022 public-v2/evaluation", file=sys.stderr)
+        sys.exit(2)
+
+    config_name = sys.argv[1]
+    data_source = sys.argv[2]
+
+    try:
+        allowed_datasets = get_allowed_datasets(config_name)
+        is_allowed = is_dataset_allowed(config_name, data_source)
+
+        # Extract dataset type from data_source
+        dataset_type = data_source.split('/')[0]
+
+        if is_allowed:
+            print(f"OK: {config_name} can run on {data_source}")
+            print(f"Allowed datasets: {', '.join(allowed_datasets)}")
+            sys.exit(0)
+        else:
+            print(f"BLOCKED: {config_name} cannot run on {data_source}", file=sys.stderr)
+            print(f"Allowed datasets: {', '.join(allowed_datasets)}", file=sys.stderr)
+            print(f"Requested dataset type: {dataset_type}", file=sys.stderr)
+            sys.exit(1)
+
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -1,4 +1,11 @@
 # Prices are in USD per 1 million tokens.
+#
+# Dataset access control:
+#   datasets: ["public-v1", "public-v2"]                              - DEFAULT if not specified
+#   datasets: ["public-v1", "public-v2", "private-v1", "private-v2"]  - includes private (requires explicit opt-in)
+#
+# Private dataset access requires explicit configuration. Models without a 'datasets'
+# field will only have access to public-v1 and public-v2 datasets.
 
 models:
   - name: "random-baseline"


### PR DESCRIPTION
## Summary
- Add `datasets` field to models.yml for controlling which datasets a model can access
- Default to `["public-v1", "public-v2"]` only; private datasets require explicit opt-in
- Add `get_allowed_datasets()` and `is_dataset_allowed()` utilities in task_utils.py
- Add `cli/check_dataset.py` for validating dataset access from shell scripts

## Dataset Configuration

Models without a `datasets` field default to public datasets only:
```yaml
datasets: ["public-v1", "public-v2"]  # DEFAULT if not specified
```

To allow private datasets, add explicit configuration:
```yaml
datasets: ["public-v1", "public-v2", "private-v1", "private-v2"]
```

## Test plan
- [ ] Verify `cli/check_dataset.py` returns exit code 0 for allowed datasets
- [ ] Verify `cli/check_dataset.py` returns exit code 1 for disallowed datasets
- [ ] Verify models without `datasets` field default to public only