### PR TITLE
Add qwen3-max-thinking via OpenRouter, move kimi-k2.5 to Fireworks

### DIFF
--- a/cli/run_all.py
+++ b/cli/run_all.py
@@ -154,7 +154,8 @@ def get_or_create_rate_limiter(
             else:
                 calculated_rps = config_rate / config_period
                 actual_rate_for_limiter = calculated_rps
-                actual_capacity_for_limiter = max(1.0, calculated_rps)
+                config_capacity = model_rate_limit.get('capacity')
+                actual_capacity_for_limiter = config_capacity if config_capacity else max(1.0, calculated_rps)
             logger.info(f"Initializing MODEL-SPECIFIC rate limiter for '{model_config.name}' with rate={actual_rate_for_limiter:.2f} req/s, capacity={actual_capacity_for_limiter:.2f}.")
         elif provider_name not in all_provider_limits:
             logger.warning(f"No rate limit configuration found for provider '{provider_name}' in provider_config.yml. Using default ({DEFAULT_RATE_LIMIT_RATE} req/{DEFAULT_RATE_LIMIT_PERIOD}s).")

--- a/src/arc_agi_benchmarking/adapters/fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/fireworks.py
@@ -1,6 +1,10 @@
 import os
+from typing import List, Dict, Any
 from openai import OpenAI
-from .openai_base import OpenAIBaseAdapter
+from .openai_base import OpenAIBaseAdapter, _filter_api_kwargs
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class FireworksAdapter(OpenAIBaseAdapter):
@@ -13,3 +17,13 @@ class FireworksAdapter(OpenAIBaseAdapter):
             raise ValueError("FIREWORKS_API_KEY not found in environment variables")
 
         return OpenAI(api_key=api_key, base_url="https://api.fireworks.ai/inference/v1")
+
+    def _chat_completion(self, messages: List[Dict[str, str]]) -> Any:
+        api_kwargs = _filter_api_kwargs(self.model_config.kwargs)
+        api_kwargs["store"] = False
+        logger.debug(
+            f"Calling Fireworks API with model: {self.model_config.model_name} and kwargs: {api_kwargs}"
+        )
+        return self.client.chat.completions.create(
+            model=self.model_config.model_name, messages=messages, **api_kwargs
+        )

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -1506,19 +1506,22 @@ models:
 ########################
 
   - name: "kimi-k2.5"
-    model_name: "moonshotai/kimi-k2.5"
-    provider: "openrouter"
+    model_name: "accounts/fireworks/models/kimi-k2p5"
+    provider: "fireworks"
     max_tokens: 100000
-    extra_body:
-      reasoning:
-        enabled: true
-    rate_limit:
-      rate: 20
-      period: 60
     pricing:
       date: "2025-01-27"
       input: 0.60
       output: 3.00
+
+  - name: "qwen3-max-thinking-openrouter"
+    model_name: "qwen/qwen3-max-thinking"
+    provider: "openrouter"
+    max_tokens: 32768
+    pricing:
+      date: "2026-02-10"
+      input: 1.20
+      output: 6.00
 
   - name: "qwen3-235b-a22b-07-25"
     model_name: "qwen/qwen3-235b-a22b-07-25"


### PR DESCRIPTION
## Summary
- Add `qwen3-max-thinking-openrouter` model config using OpenRouter (`qwen/qwen3-max-thinking`, $1.20/$6.00 per 1M tokens)
- Switch `kimi-k2.5` from OpenRouter to Fireworks (`accounts/fireworks/models/kimi-k2p5`)
- Hardcode `store=False` in `FireworksAdapter._chat_completion()` to opt out of Fireworks conversation data retention

## Test plan
- [x] Verified qwen3-max-thinking-openrouter runs successfully on a single v2 eval task (0934a4d8)
- [x] Verify kimi-k2.5 via Fireworks once `FIREWORKS_API_KEY` is configured