### PR TITLE
Add Message Batches API support to Anthropic adapter

### DIFF
--- a/src/arc_agi_benchmarking/adapters/anthropic.py
+++ b/src/arc_agi_benchmarking/adapters/anthropic.py
@@ -1,13 +1,20 @@
 from .provider import ProviderAdapter
 from arc_agi_benchmarking.schemas import ARCTaskOutput, AttemptMetadata, Choice, Message, Usage, Cost, CompletionTokensDetails, Attempt
 import anthropic
+from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
+from anthropic.types.messages.batch_create_params import Request
 import os
 import json
+import uuid
+import time
 from typing import List, Optional, Any
 from datetime import datetime, timezone
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Poll batch status every 10 seconds (matches OpenAI background mode polling cadence)
+_BATCH_POLL_INTERVAL_SECONDS = 10
 
 class AnthropicAdapter(ProviderAdapter):
     def init_client(self):
@@ -38,10 +45,16 @@ class AnthropicAdapter(ProviderAdapter):
             {"role": "user", "content": prompt}
         ]
 
-        # Check if streaming is enabled
+        # Check if streaming / batch mode are enabled
         stream_enabled = self.model_config.kwargs.get('stream', False) or getattr(self.model_config, 'stream', False)
+        batch_enabled = self.model_config.kwargs.get('batch', False) or getattr(self.model_config, 'batch', False)
 
-        if stream_enabled:
+        if batch_enabled and stream_enabled:
+            raise ValueError("Cannot enable both 'stream' and 'batch' for Anthropic. Batch requests do not support streaming.")
+
+        if batch_enabled:
+            response = self.chat_completion_batch(messages)
+        elif stream_enabled:
             response = self.chat_completion_stream(messages)
         else:
             response = self.chat_completion(messages)
@@ -163,7 +176,6 @@ class AnthropicAdapter(ProviderAdapter):
 
         try:
             if betas:
-                print ("stream kwargs", stream_kwargs)
                 with self.client.beta.messages.stream(
                     model=self.model_config.model_name,
                     betas=betas,
@@ -189,6 +201,107 @@ class AnthropicAdapter(ProviderAdapter):
             logger.error(f"Error during Anthropic streaming: {e}")
             logger.error(f"Error details: {e.response}")
             raise
+
+    def chat_completion_batch(self, messages, tools=[]):
+        """
+        Submit a single Messages request via Anthropic's Message Batches API,
+        poll until processing has ended, fetch the result, and delete the batch.
+
+        Mirrors OpenAI's background-mode pattern: the batch is always deleted
+        afterwards so the request doesn't sit in Anthropic's batch storage.
+        Returns the Anthropic Message object so the caller can treat it the
+        same as a synchronous Messages API response.
+        """
+        # Build params for the single batched request. Strip flags that aren't
+        # valid inside batch params: our internal 'batch' flag, 'stream' (not
+        # supported in batches), and 'betas' (passed at the batch level below).
+        betas = self.model_config.kwargs.get('betas')
+        batch_kwargs = {
+            k: v for k, v in self.model_config.kwargs.items()
+            if k not in ('batch', 'stream', 'betas')
+        }
+
+        # `extra_body` is an SDK-level escape hatch the synchronous Messages
+        # SDK merges into the final HTTP body. In batch mode, per-request
+        # `params` are sent verbatim (no SDK merging step), so a literal
+        # `extra_body` key would be rejected as "Extra inputs are not
+        # permitted". Mirror the sync behavior here by inlining extra_body's
+        # contents directly into the per-request params.
+        extra_body = batch_kwargs.pop('extra_body', None) or {}
+
+        custom_id = f"arc-{uuid.uuid4().hex[:16]}"
+
+        params: dict = MessageCreateParamsNonStreaming(
+            model=self.model_config.model_name,
+            messages=messages,
+            tools=tools,
+            **batch_kwargs,
+        )
+        # Inline extra_body fields (e.g. output_config, context_management)
+        # into the top level of params, matching how the sync SDK serializes them.
+        for k, v in extra_body.items():
+            params[k] = v
+
+        request = Request(custom_id=custom_id, params=params)
+
+        # Route through beta batches endpoint if a betas list is configured
+        batches_api = self.client.beta.messages.batches if betas else self.client.messages.batches
+
+        if betas:
+            batch = batches_api.create(requests=[request], betas=betas)
+        else:
+            batch = batches_api.create(requests=[request])
+
+        batch_id = batch.id
+        logger.debug(f"Created Anthropic batch {batch_id} with custom_id={custom_id}")
+
+        try:
+            # Poll until processing ends. No hard cap: matches OpenAI background
+            # mode, which also loops until the response leaves queued/in_progress.
+            while batch.processing_status != "ended":
+                time.sleep(_BATCH_POLL_INTERVAL_SECONDS)
+                batch = batches_api.retrieve(batch_id)
+                logger.debug(
+                    f"Anthropic batch {batch_id} status={batch.processing_status} "
+                    f"counts={batch.request_counts}"
+                )
+
+            # Stream results back; we only submitted one request so we expect one entry.
+            matched = None
+            for result in batches_api.results(batch_id):
+                if result.custom_id == custom_id:
+                    matched = result
+                    break
+
+            if matched is None:
+                raise RuntimeError(
+                    f"Anthropic batch {batch_id} returned no result for custom_id={custom_id}"
+                )
+
+            result_type = matched.result.type
+            if result_type == "succeeded":
+                return matched.result.message
+            if result_type == "errored":
+                err = getattr(matched.result, "error", None)
+                raise RuntimeError(
+                    f"Anthropic batch request {custom_id} errored: {err}"
+                )
+            if result_type == "canceled":
+                raise RuntimeError(f"Anthropic batch request {custom_id} was canceled")
+            if result_type == "expired":
+                raise RuntimeError(f"Anthropic batch request {custom_id} expired")
+            raise RuntimeError(
+                f"Anthropic batch request {custom_id} returned unknown result type: {result_type}"
+            )
+        finally:
+            # Always delete the batch from Anthropic's storage, regardless of
+            # success or failure above. Failures here are logged but do not
+            # override the original exception (if any).
+            try:
+                batches_api.delete(batch_id)
+                logger.debug(f"Deleted Anthropic batch {batch_id}")
+            except Exception as delete_err:
+                logger.warning(f"Failed to delete Anthropic batch {batch_id}: {delete_err}")
 
     def _get_reasoning_summary(self, response: Any) -> str:
         """Get the reasoning summary from the response."""

--- a/src/arc_agi_benchmarking/tests/test_anthropic.py
+++ b/src/arc_agi_benchmarking/tests/test_anthropic.py
@@ -134,3 +134,276 @@ class TestAnthropicStreaming:
                 max_tokens=8192
             )
             assert result == mock_anthropic_response
+
+
+def _make_batch_handle(batch_id="msgbatch_test", status_sequence=("ended",)):
+    """
+    Build a mock batches API namespace whose retrieve() returns successive
+    batches with the given processing_status values, then sticks on the last one.
+    """
+    status_iter = iter(status_sequence)
+
+    def _next_batch():
+        try:
+            status = next(status_iter)
+        except StopIteration:
+            status = status_sequence[-1]
+        b = Mock()
+        b.id = batch_id
+        b.processing_status = status
+        b.request_counts = Mock()
+        return b
+
+    batches = Mock()
+    batches.create = Mock(side_effect=lambda *a, **kw: _next_batch())
+    batches.retrieve = Mock(side_effect=lambda _id: _next_batch())
+    batches.results = Mock()
+    batches.delete = Mock()
+    return batches
+
+
+def _make_succeeded_result(custom_id, message):
+    """Build a single succeeded batch result entry."""
+    result = Mock()
+    result.custom_id = custom_id
+    result.result = Mock()
+    result.result.type = "succeeded"
+    result.result.message = message
+    return result
+
+
+class TestAnthropicBatch:
+    """Test Message Batches API integration for the Anthropic adapter."""
+
+    def test_batch_and_stream_together_raises(self, adapter_instance):
+        """batch=True + stream=True should be rejected before any API call."""
+        adapter_instance.model_config.kwargs = {
+            'batch': True,
+            'stream': True,
+            'max_tokens': 8192,
+        }
+
+        with pytest.raises(ValueError, match="Cannot enable both 'stream' and 'batch'"):
+            adapter_instance.make_prediction("Hello")
+
+    def test_make_prediction_routes_to_batch(self, adapter_instance, mock_anthropic_response):
+        """When batch=True, make_prediction must call chat_completion_batch."""
+        adapter_instance.model_config.kwargs = {'batch': True, 'max_tokens': 8192}
+
+        with patch.object(adapter_instance, 'chat_completion_batch') as mock_batch:
+            mock_batch.return_value = mock_anthropic_response
+
+            attempt = adapter_instance.make_prediction("Hello")
+
+            mock_batch.assert_called_once()
+            assert attempt.answer == [[1, 2], [3, 4]]
+
+    def test_chat_completion_batch_create_poll_results_delete(self, adapter_instance, mock_anthropic_response):
+        """
+        chat_completion_batch must:
+          1. create a batch with a single Request,
+          2. poll until processing_status == 'ended',
+          3. fetch results and return the message for our custom_id,
+          4. delete the batch afterwards.
+        """
+        adapter_instance.model_config.kwargs = {'batch': True, 'max_tokens': 8192}
+
+        batches = _make_batch_handle(
+            batch_id="msgbatch_abc",
+            status_sequence=("in_progress", "in_progress", "ended"),
+        )
+        adapter_instance.client.messages.batches = batches
+
+        # Capture custom_id from the create() call so we can return a matching result
+        captured = {}
+        original_create = batches.create.side_effect
+
+        def capture_create(*args, **kwargs):
+            captured['requests'] = kwargs.get('requests') or (args[0] if args else None)
+            return original_create(*args, **kwargs)
+
+        batches.create.side_effect = capture_create
+
+        # Patch sleep so the poll loop doesn't actually wait
+        with patch('arc_agi_benchmarking.adapters.anthropic.time.sleep') as mock_sleep:
+            # results() will be called after the batch ends; return our message
+            def results_side_effect(_batch_id):
+                custom_id = captured['requests'][0]['custom_id']
+                return iter([_make_succeeded_result(custom_id, mock_anthropic_response)])
+
+            batches.results.side_effect = results_side_effect
+
+            messages = [{"role": "user", "content": "Hi"}]
+            result = adapter_instance.chat_completion_batch(messages)
+
+        # Returned message is the underlying Anthropic message object
+        assert result is mock_anthropic_response
+
+        # create called exactly once, with one Request, no betas kwarg
+        batches.create.assert_called_once()
+        create_kwargs = batches.create.call_args.kwargs
+        assert 'betas' not in create_kwargs
+        assert len(create_kwargs['requests']) == 1
+        req = create_kwargs['requests'][0]
+        assert req['custom_id'].startswith('arc-')
+        # 'batch' and 'stream' must NOT be passed through into the per-request params
+        params = req['params']
+        assert 'batch' not in params
+        assert 'stream' not in params
+        assert params['model'] == "claude-3-7-sonnet-20250219"
+        assert params['max_tokens'] == 8192
+
+        # Poll loop ran (in_progress -> in_progress -> ended = 2 retrieves)
+        assert batches.retrieve.call_count == 2
+        # And it slept between polls
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(10)
+
+        # Delete was called with the batch id
+        batches.delete.assert_called_once_with("msgbatch_abc")
+
+    def test_chat_completion_batch_deletes_even_on_errored_result(self, adapter_instance):
+        """If the result type is 'errored', we must still delete the batch."""
+        adapter_instance.model_config.kwargs = {'batch': True, 'max_tokens': 8192}
+
+        batches = _make_batch_handle(batch_id="msgbatch_err", status_sequence=("ended",))
+        adapter_instance.client.messages.batches = batches
+
+        captured = {}
+        original_create = batches.create.side_effect
+
+        def capture_create(*args, **kwargs):
+            captured['requests'] = kwargs.get('requests') or (args[0] if args else None)
+            return original_create(*args, **kwargs)
+
+        batches.create.side_effect = capture_create
+
+        def results_side_effect(_batch_id):
+            custom_id = captured['requests'][0]['custom_id']
+            errored = Mock()
+            errored.custom_id = custom_id
+            errored.result = Mock()
+            errored.result.type = "errored"
+            errored.result.error = "some_error"
+            return iter([errored])
+
+        batches.results.side_effect = results_side_effect
+
+        with patch('arc_agi_benchmarking.adapters.anthropic.time.sleep'):
+            with pytest.raises(RuntimeError, match="errored"):
+                adapter_instance.chat_completion_batch([{"role": "user", "content": "Hi"}])
+
+        # Delete is still called even though we raised
+        batches.delete.assert_called_once_with("msgbatch_err")
+
+    def test_chat_completion_batch_routes_to_beta_when_betas_set(self, adapter_instance, mock_anthropic_response):
+        """When 'betas' is in kwargs, requests must go through client.beta.messages.batches."""
+        adapter_instance.model_config.kwargs = {
+            'batch': True,
+            'max_tokens': 8192,
+            'betas': ['some-beta-flag'],
+        }
+
+        beta_batches = _make_batch_handle(batch_id="msgbatch_beta", status_sequence=("ended",))
+        adapter_instance.client.beta.messages.batches = beta_batches
+
+        captured = {}
+        original_create = beta_batches.create.side_effect
+
+        def capture_create(*args, **kwargs):
+            captured['requests'] = kwargs.get('requests') or (args[0] if args else None)
+            captured['betas'] = kwargs.get('betas')
+            return original_create(*args, **kwargs)
+
+        beta_batches.create.side_effect = capture_create
+
+        def results_side_effect(_batch_id):
+            custom_id = captured['requests'][0]['custom_id']
+            return iter([_make_succeeded_result(custom_id, mock_anthropic_response)])
+
+        beta_batches.results.side_effect = results_side_effect
+
+        with patch('arc_agi_benchmarking.adapters.anthropic.time.sleep'):
+            result = adapter_instance.chat_completion_batch([{"role": "user", "content": "Hi"}])
+
+        assert result is mock_anthropic_response
+        # Went through beta endpoint with the betas kwarg
+        beta_batches.create.assert_called_once()
+        assert captured['betas'] == ['some-beta-flag']
+        # 'betas' was NOT leaked into per-request params
+        assert 'betas' not in captured['requests'][0]['params']
+        beta_batches.delete.assert_called_once_with("msgbatch_beta")
+
+    def test_chat_completion_batch_inlines_extra_body_into_params(self, adapter_instance, mock_anthropic_response):
+        """
+        Regression test for the 'extra_body: Extra inputs are not permitted' error.
+
+        The Anthropic batches API sends per-request `params` verbatim. The SDK-level
+        `extra_body` escape hatch only works on the sync Messages API (where the SDK
+        merges it into the JSON body). For batch requests we must inline its contents
+        into the params dict ourselves.
+        """
+        adapter_instance.model_config.kwargs = {
+            'batch': True,
+            'max_tokens': 8192,
+            'extra_body': {'output_config': {'effort': 'low'}},
+        }
+
+        batches = _make_batch_handle(batch_id="msgbatch_eb", status_sequence=("ended",))
+        adapter_instance.client.messages.batches = batches
+
+        captured = {}
+        original_create = batches.create.side_effect
+
+        def capture_create(*args, **kwargs):
+            captured['requests'] = kwargs.get('requests') or (args[0] if args else None)
+            return original_create(*args, **kwargs)
+
+        batches.create.side_effect = capture_create
+
+        def results_side_effect(_batch_id):
+            custom_id = captured['requests'][0]['custom_id']
+            return iter([_make_succeeded_result(custom_id, mock_anthropic_response)])
+
+        batches.results.side_effect = results_side_effect
+
+        with patch('arc_agi_benchmarking.adapters.anthropic.time.sleep'):
+            adapter_instance.chat_completion_batch([{"role": "user", "content": "Hi"}])
+
+        params = captured['requests'][0]['params']
+        # extra_body must NOT appear as a literal key in params
+        assert 'extra_body' not in params, \
+            "'extra_body' leaked into batch params and will be rejected by Anthropic"
+        # Its contents must be merged into params at the top level
+        assert params.get('output_config') == {'effort': 'low'}, \
+            "extra_body contents were not inlined into params"
+
+    def test_chat_completion_batch_delete_failure_does_not_raise(self, adapter_instance, mock_anthropic_response):
+        """If delete fails, we should log a warning but not raise (matches OpenAI bg-mode behavior)."""
+        adapter_instance.model_config.kwargs = {'batch': True, 'max_tokens': 8192}
+
+        batches = _make_batch_handle(batch_id="msgbatch_del", status_sequence=("ended",))
+        batches.delete.side_effect = Exception("delete failed")
+        adapter_instance.client.messages.batches = batches
+
+        captured = {}
+        original_create = batches.create.side_effect
+
+        def capture_create(*args, **kwargs):
+            captured['requests'] = kwargs.get('requests') or (args[0] if args else None)
+            return original_create(*args, **kwargs)
+
+        batches.create.side_effect = capture_create
+
+        def results_side_effect(_batch_id):
+            custom_id = captured['requests'][0]['custom_id']
+            return iter([_make_succeeded_result(custom_id, mock_anthropic_response)])
+
+        batches.results.side_effect = results_side_effect
+
+        with patch('arc_agi_benchmarking.adapters.anthropic.time.sleep'):
+            # Should NOT raise even though delete blew up
+            result = adapter_instance.chat_completion_batch([{"role": "user", "content": "Hi"}])
+
+        assert result is mock_anthropic_response
+        batches.delete.assert_called_once_with("msgbatch_del")


### PR DESCRIPTION
## Summary

Adds a `batch` flag for Anthropic models that routes requests through Anthropic's [Message Batches API](https://docs.anthropic.com/en/api/creating-message-batches).

The adapter submits a single request, polls until processing ends, fetches the result, and always deletes the batch from Anthropic's storage afterward (mirroring the existing OpenAI background-mode handling).

## Details

- `batch` and `stream` are mutually exclusive and raise if both are set (batch requests don't support streaming).
- `extra_body` contents are inlined into the per-request params, since the batches API sends `params` verbatim and would reject a literal `extra_body` key ("Extra inputs are not permitted").
- Routes through the beta batches endpoint when `betas` is configured.
- Removes a stray debug `print` in the streaming path.

## Tests

New `TestAnthropicBatch` suite covers:
- `batch` + `stream` rejection
- `make_prediction` routing to the batch path
- the full create → poll → results → delete lifecycle
- batch deletion even on an errored result
- beta endpoint routing (and `betas` not leaking into params)
- `extra_body` inlining (regression for the "Extra inputs are not permitted" error)
- delete-failure handling (logs, doesn't raise)

All 11 Anthropic tests pass; full suite: 495 passed, 9 skipped. Also smoke-tested live end-to-end on a single sample task (create/poll/results/delete completed, correct output).