### PR TITLE
Add custom base_url support for OpenAI-compatible endpoints

### DIFF
--- a/src/arc_agi_benchmarking/adapters/open_ai.py
+++ b/src/arc_agi_benchmarking/adapters/open_ai.py
@@ -7,11 +7,19 @@ class OpenAIAdapter(OpenAIBaseAdapter):
     """Adapter for OpenAI API."""
 
     def init_client(self):
-        """Initialize the OpenAI client."""
-        if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("OPENAI_API_KEY not found in environment variables")
+        """Initialize the OpenAI client.
 
-        return OpenAI(
-            max_retries=0,
-            timeout=1800,
-        )
+        Honors optional `base_url` and `api_key_env` from the model config so the
+        OpenAI adapter can target any OpenAI-compatible endpoint. Defaults preserve
+        the standard OpenAI behavior (OPENAI_API_KEY + default base URL).
+        """
+        api_key_env = self.model_config.api_key_env or "OPENAI_API_KEY"
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            raise ValueError(f"{api_key_env} not found in environment variables")
+
+        client_kwargs = {"api_key": api_key, "max_retries": 0, "timeout": 1800}
+        if self.model_config.base_url:
+            client_kwargs["base_url"] = self.model_config.base_url
+
+        return OpenAI(**client_kwargs)

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -9,6 +9,27 @@ models:
       input: 0.0
       output: 0.0
 
+###############################################
+### OpenAI-compatible endpoints (custom URL) ###
+###############################################
+
+# Example: any OpenAI-compatible provider can reuse the `openai` adapter by
+# setting `base_url` and `api_key_env`. No new adapter class is required.
+# Below targets Baseten's OpenAI-compatible endpoint. Replace pricing with the
+# provider's actual per-1M-token rates before relying on cost reporting.
+  - name: "baseten-glm-5-2"
+    model_name: "zai-org/GLM-5.2"
+    provider: "openai"
+    api_type: "chat_completions"
+    base_url: "https://inference.baseten.co/v1"
+    api_key_env: "BASETEN_API_KEY"
+    temperature: 1
+    max_tokens: 16000
+    pricing:
+      date: "2026-06-18"
+      input: 0.0
+      output: 0.0
+
 ################
 ### Together ###
 ################

--- a/src/arc_agi_benchmarking/schemas.py
+++ b/src/arc_agi_benchmarking/schemas.py
@@ -266,6 +266,8 @@ class ModelConfig(BaseModel):
     provider: str
     pricing: ModelPricing
     api_type: Optional[str] = APIType.CHAT_COMPLETIONS # currently only used by openai
+    base_url: Optional[str] = None  # override the provider's default API endpoint (OpenAI-compatible providers)
+    api_key_env: Optional[str] = None  # name of the env var holding the API key (not the secret itself)
     kwargs: Dict[str, Any] = {}
     
     model_config = {
@@ -281,7 +283,7 @@ class ModelConfig(BaseModel):
             return values
             
         kwargs = {}
-        known_fields = {'name', 'provider', 'pricing', 'kwargs', 'model_name', 'api_type'}
+        known_fields = {'name', 'provider', 'pricing', 'kwargs', 'model_name', 'api_type', 'base_url', 'api_key_env'}
         
         for field_name, value in values.items():
             if field_name not in known_fields:

--- a/src/arc_agi_benchmarking/tests/test_custom_base_url.py
+++ b/src/arc_agi_benchmarking/tests/test_custom_base_url.py
@@ -1,0 +1,103 @@
+"""Tests for OpenAI-compatible custom endpoints via `base_url` / `api_key_env`.
+
+These verify that the standard `openai` adapter can target any OpenAI-compatible
+provider by setting `base_url` and `api_key_env` in the model config, without a
+dedicated adapter class. Baseten is used as the running example.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from arc_agi_benchmarking.adapters.open_ai import OpenAIAdapter
+from arc_agi_benchmarking.schemas import APIType, ModelConfig, ModelPricing
+
+
+def _make_config(**overrides) -> ModelConfig:
+    """Build a ModelConfig, allowing extra/override fields per test."""
+    base = dict(
+        name="baseten-glm-5-2",
+        model_name="zai-org/GLM-5.2",
+        provider="openai",
+        pricing=ModelPricing(date="2026-06-18", input=0.0, output=0.0),
+        api_type=APIType.CHAT_COMPLETIONS,
+    )
+    base.update(overrides)
+    return ModelConfig(**base)
+
+
+def _init_client_with_config(config: ModelConfig):
+    """Run OpenAIAdapter.init_client() against a config, mocking the OpenAI SDK.
+
+    Returns the (args, kwargs) the OpenAI client was constructed with.
+    """
+    # Bypass ProviderAdapter.__init__ so no real config-name lookup happens.
+    with patch(
+        "arc_agi_benchmarking.adapters.provider.ProviderAdapter.__init__",
+        return_value=None,
+    ):
+        adapter = OpenAIAdapter(config=config.name)
+        adapter.model_config = config
+
+        with patch("arc_agi_benchmarking.adapters.open_ai.OpenAI") as mock_openai:
+            adapter.init_client()
+
+    mock_openai.assert_called_once()
+    return mock_openai.call_args
+
+
+class TestCustomBaseUrlSchema:
+    """The new fields must be first-class, not swept into kwargs by the validator."""
+
+    def test_base_url_and_api_key_env_are_first_class_fields(self):
+        config = _make_config(
+            base_url="https://inference.baseten.co/v1",
+            api_key_env="BASETEN_API_KEY",
+        )
+        assert config.base_url == "https://inference.baseten.co/v1"
+        assert config.api_key_env == "BASETEN_API_KEY"
+        # Critical: these must NOT leak into kwargs, or they'd be passed as API
+        # request params to chat.completions.create() and rejected by the SDK.
+        assert "base_url" not in config.kwargs
+        assert "api_key_env" not in config.kwargs
+
+    def test_fields_default_to_none(self):
+        config = _make_config()
+        assert config.base_url is None
+        assert config.api_key_env is None
+
+
+class TestCustomBaseUrlClientInit:
+    """init_client() should honor base_url / api_key_env from the config."""
+
+    def test_uses_custom_base_url_and_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("BASETEN_API_KEY", "baseten-secret")
+        config = _make_config(
+            base_url="https://inference.baseten.co/v1",
+            api_key_env="BASETEN_API_KEY",
+        )
+
+        call_args = _init_client_with_config(config)
+
+        assert call_args.kwargs["base_url"] == "https://inference.baseten.co/v1"
+        assert call_args.kwargs["api_key"] == "baseten-secret"
+
+    def test_defaults_preserve_standard_openai_behavior(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+        monkeypatch.delenv("BASETEN_API_KEY", raising=False)
+        config = _make_config(provider="openai")  # no base_url / api_key_env
+
+        call_args = _init_client_with_config(config)
+
+        # No base_url override should be passed when not configured.
+        assert "base_url" not in call_args.kwargs
+        assert call_args.kwargs["api_key"] == "openai-secret"
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("BASETEN_API_KEY", raising=False)
+        config = _make_config(
+            base_url="https://inference.baseten.co/v1",
+            api_key_env="BASETEN_API_KEY",
+        )
+
+        with pytest.raises(ValueError, match="BASETEN_API_KEY"):
+            _init_client_with_config(config)


### PR DESCRIPTION
## Summary

Lets the existing `openai` adapter target **any OpenAI-compatible endpoint** by setting two optional fields on a model config — `base_url` and `api_key_env` — instead of writing a dedicated adapter class per provider.

This means adding an OpenAI-compatible provider (Baseten, Together-style endpoints, local servers, etc.) becomes a pure `models.yml` edit:

```yaml
- name: "baseten-glm-5-2"
  model_name: "zai-org/GLM-5.2"
  provider: "openai"          # reuse the OpenAI adapter
  api_type: "chat_completions"
  base_url: "https://inference.baseten.co/v1"
  api_key_env: "BASETEN_API_KEY"
```

## Changes

- **`schemas.py`**: add first-class `base_url` and `api_key_env` fields to `ModelConfig`, and register them in the validator's `known_fields`. This last part is load-bearing: `ModelConfig` uses `extra: 'allow'` and sweeps unknown top-level fields into `kwargs`, which get splatted into the API request — so these fields must be recognized or they'd be passed as bogus request params and rejected by the SDK.
- **`open_ai.py`**: `init_client()` honors `base_url` / `api_key_env`. Defaults are unchanged — no config means `OPENAI_API_KEY` + the default OpenAI base URL, so existing configs behave exactly as before.
- **`models.yml`**: documented example targeting Baseten's OpenAI-compatible endpoint.
- **tests**: `test_custom_base_url.py` covers first-class field handling (not leaking into kwargs), client init with a custom URL/key, default-preserving behavior, and the missing-key error.

## Notes

- `api_key_env` stores the **name** of the env var, not the secret — keeps secrets out of `models.yml`.
- The example uses `pricing: 0.0`; replace with the provider's real per-1M-token rates before relying on cost reporting.
- Trade-off: `provider: openai` denotes the wire protocol, not the vendor, so rate-limit buckets (`provider_config.yml`) and cost attribution group all OpenAI-compatible configs together. A thin subclass is still the right move if a provider needs its own rate limits.

## Testing

- New tests pass (5/5).
- Full suite green: 500 passed, 9 skipped.
- Verified end-to-end against Baseten GLM-5.2 on sample task `66e6c45b` — produced the correct grid and passed token reconciliation.