### PR TITLE
Handle missing Gemini reasoning token counts

### DIFF
--- a/src/arc_agi_benchmarking/adapters/gemini.py
+++ b/src/arc_agi_benchmarking/adapters/gemini.py
@@ -82,10 +82,15 @@ class GeminiAdapter(ProviderAdapter):
         usage_metadata = getattr(response, 'usage_metadata', None)
         logger.debug(f"Response usage metadata: {usage_metadata}")
         
-        input_tokens = getattr(usage_metadata, 'prompt_token_count', 0) if usage_metadata else 0
-        output_tokens = getattr(usage_metadata, 'candidates_token_count', 0) if usage_metadata else 0
-        reasoning_tokens = getattr(usage_metadata, 'thoughts_token_count', 0) if usage_metadata else 0
-        total_tokens = getattr(usage_metadata, 'total_token_count', 0) if usage_metadata else 0
+        # Gemini leaves token counts as None when a category is unused. In
+        # particular, minimal thinking commonly returns thoughts_token_count=None.
+        def token_count(field: str) -> int:
+            return (getattr(usage_metadata, field, 0) or 0) if usage_metadata else 0
+
+        input_tokens = token_count('prompt_token_count')
+        output_tokens = token_count('candidates_token_count')
+        reasoning_tokens = token_count('thoughts_token_count')
+        total_tokens = token_count('total_token_count')
         
         response_text = getattr(response, 'text', "")
 

--- a/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
+++ b/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
@@ -1,6 +1,12 @@
 """Compatibility tests for the pinned Google Gen AI SDK."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 from google.genai import types
+
+from arc_agi_benchmarking.adapters.gemini import GeminiAdapter
 
 
 def test_gemini_sdk_supports_thinking_level():
@@ -10,3 +16,32 @@ def test_gemini_sdk_supports_thinking_level():
 
     assert config.thinking_config is not None
     assert config.thinking_config.thinking_level == types.ThinkingLevel.MEDIUM
+
+
+def test_minimal_thinking_treats_missing_reasoning_tokens_as_zero():
+    adapter = object.__new__(GeminiAdapter)
+    adapter.model_config = SimpleNamespace(
+        model_name="gemini-3.6-flash",
+        provider="gemini",
+        kwargs={"thinking_config": {"thinking_level": "minimal"}},
+        pricing=SimpleNamespace(input=1.5, output=7.5),
+    )
+    adapter.chat_completion = MagicMock(
+        return_value=SimpleNamespace(
+            text="[[1]]",
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=100,
+                candidates_token_count=20,
+                thoughts_token_count=None,
+                total_token_count=120,
+            ),
+        )
+    )
+
+    attempt = adapter.make_prediction("Solve this task")
+
+    assert attempt.metadata.usage.completion_tokens_details.reasoning_tokens == 0
+    assert attempt.metadata.cost.reasoning_cost == 0
+    assert attempt.metadata.cost.total_cost == pytest.approx(
+        (100 * 1.5 / 1_000_000) + (20 * 7.5 / 1_000_000)
+    )


### PR DESCRIPTION
## Background

Gemini 3.6 Flash with `thinking_level="minimal"` can return `usage_metadata.thoughts_token_count=None` when no reasoning tokens are used. The Gemini adapter passed that value directly into cost calculation, causing a successful API response to fail locally with:

```text
unsupported operand type(s) for *: 'NoneType' and 'float'
```

The benchmark then retried the prediction and produced no submission even though Gemini had responded successfully.

## Changes

- normalize optional Gemini usage token counts from `None` to zero before constructing usage and cost metadata
- add a regression test for minimal thinking with a missing reasoning-token count
- verify prompt and completion costs remain unchanged while reasoning cost becomes zero

## Testing

- `uv run python -m pytest -q src/arc_agi_benchmarking/tests/test_gemini_sdk.py` (2 passed)
- `uv run python -m pytest -q` (502 passed, 9 skipped)