### PR TITLE
Require explicit API key configuration across providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # API Keys for various providers
 # Copy this file to .env and fill in your actual API keys.
-# Ensure the variable name matches what the adapter expects (e.g., OPENAI_API_KEY).
+# Ensure the variable name matches api_key_env in the model config.
 # -----------------------------------------------------------------------------
 
 # Anthropic

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
   - name: "gpt-4o-2024-11-20"   # config name you reference on the CLI; typically includes the reasoning level for clarity (e.g., "-basic", "-advanced")
     model_name: "gpt-4o-2024-11-20"  # provider’s actual model id
     provider: "openai"         # must match an adapter
+    api_key_env: "OPENAI_API_KEY"  # required for the OpenAI adapter
     max_output_tokens: 4096    # optional; provider-specific
     temperature: 0.0           # optional; provider-specific
     pricing:
@@ -90,7 +91,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
       output: 15.00            # USD per 1M output tokens
   ```
   - Standard fields: `name`, `model_name`, `provider`, `pricing` (`input`/`output` per 1M tokens, `date` for traceability).
-  - OpenAI API keys: configs with `provider: openai` use `OPENAI_API_KEY` when `api_key_env` is omitted. For an OpenAI-compatible endpoint that requires a different key, set `api_key_env` to that environment variable (typically alongside `base_url`). When `api_key_env` is set, that key is required and does not fall back to `OPENAI_API_KEY`.
+  - OpenAI API keys: every config using `provider: openai` must explicitly set `api_key_env`. Use `OPENAI_API_KEY` for OpenAI itself. When reusing the OpenAI adapter for a compatible endpoint, name that provider's environment variable instead (typically alongside `base_url`). The adapter never assumes or falls back to `OPENAI_API_KEY`.
   - Provider kwargs: any extra keys become `kwargs` and are passed directly to the SDK (e.g., `temperature`, `max_output_tokens`, `stream`, etc.).
 - Rate limits live in `provider_config.yml` (`rate`, `period` per provider).
 - Environment: set provider keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `HUGGING_FACE_API_KEY`). Copy `.env.example` to `.env` and fill in.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
       output: 15.00            # USD per 1M output tokens
   ```
   - Standard fields: `name`, `model_name`, `provider`, `pricing` (`input`/`output` per 1M tokens, `date` for traceability).
-  - OpenAI API keys: every config using `provider: openai` must explicitly set `api_key_env`. Use `OPENAI_API_KEY` for OpenAI itself. When reusing the OpenAI adapter for a compatible endpoint, name that provider's environment variable instead (typically alongside `base_url`). The adapter never assumes or falls back to `OPENAI_API_KEY`.
+  - API keys: every config using `provider: openai` must set `api_key_env` to the environment variable containing its API key. The adapter does not provide a default.
   - Provider kwargs: any extra keys become `kwargs` and are passed directly to the SDK (e.g., `temperature`, `max_output_tokens`, `stream`, etc.).
 - Rate limits live in `provider_config.yml` (`rate`, `period` per provider).
 - Environment: set provider keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `HUGGING_FACE_API_KEY`). Copy `.env.example` to `.env` and fill in.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
       output: 15.00            # USD per 1M output tokens
   ```
   - Standard fields: `name`, `model_name`, `provider`, `pricing` (`input`/`output` per 1M tokens, `date` for traceability).
+  - OpenAI API keys: configs with `provider: openai` use `OPENAI_API_KEY` when `api_key_env` is omitted. For an OpenAI-compatible endpoint that requires a different key, set `api_key_env` to that environment variable (typically alongside `base_url`). When `api_key_env` is set, that key is required and does not fall back to `OPENAI_API_KEY`.
   - Provider kwargs: any extra keys become `kwargs` and are passed directly to the SDK (e.g., `temperature`, `max_output_tokens`, `stream`, etc.).
 - Rate limits live in `provider_config.yml` (`rate`, `period` per provider).
 - Environment: set provider keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `HUGGING_FACE_API_KEY`). Copy `.env.example` to `.env` and fill in.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
   - name: "gpt-4o-2024-11-20"   # config name you reference on the CLI; typically includes the reasoning level for clarity (e.g., "-basic", "-advanced")
     model_name: "gpt-4o-2024-11-20"  # provider’s actual model id
     provider: "openai"         # must match an adapter
-    api_key_env: "OPENAI_API_KEY"  # required for the OpenAI adapter
+    api_key_env: "OPENAI_API_KEY"  # required unless provider is random
     max_output_tokens: 4096    # optional; provider-specific
     temperature: 0.0           # optional; provider-specific
     pricing:
@@ -91,7 +91,7 @@ Model configs live in `src/arc_agi_benchmarking/models.yml`. Example:
       output: 15.00            # USD per 1M output tokens
   ```
   - Standard fields: `name`, `model_name`, `provider`, `pricing` (`input`/`output` per 1M tokens, `date` for traceability).
-  - API keys: every config using `provider: openai` must set `api_key_env` to the environment variable containing its API key. The adapter does not provide a default.
+  - API keys: every config except `provider: random` must set `api_key_env` to the environment variable containing its API key. Every adapter reads the named variable; adapters do not provide defaults.
   - Provider kwargs: any extra keys become `kwargs` and are passed directly to the SDK (e.g., `temperature`, `max_output_tokens`, `stream`, etc.).
 - Rate limits live in `provider_config.yml` (`rate`, `period` per provider).
 - Environment: set provider keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `HUGGING_FACE_API_KEY`). Copy `.env.example` to `.env` and fill in.

--- a/src/arc_agi_benchmarking/adapters/anthropic.py
+++ b/src/arc_agi_benchmarking/adapters/anthropic.py
@@ -3,7 +3,6 @@ from arc_agi_benchmarking.schemas import ARCTaskOutput, AttemptMetadata, Choice,
 import anthropic
 from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
 from anthropic.types.messages.batch_create_params import Request
-import os
 import json
 import uuid
 import time
@@ -21,11 +20,8 @@ class AnthropicAdapter(ProviderAdapter):
         """
         Initialize the Anthropic model
         """
-        if not os.environ.get("ANTHROPIC_API_KEY"):
-            raise ValueError("ANTHROPIC_API_KEY not found in environment variables")
-
         client = anthropic.Anthropic(
-            api_key=os.environ.get("ANTHROPIC_API_KEY"),
+            api_key=self.get_api_key(),
         )
 
         return client

--- a/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
+++ b/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
@@ -37,10 +37,9 @@ This iterative approach will help you solve the puzzle more accurately.
     def init_client(self):
         """
         Initialize the Claude Agent SDK.
-        The SDK uses ANTHROPIC_API_KEY from environment.
+        The configured key is passed to the SDK as ANTHROPIC_API_KEY.
         """
-        if not os.environ.get("ANTHROPIC_API_KEY"):
-            raise ValueError("ANTHROPIC_API_KEY not found in environment variables")
+        self._api_key = self.get_api_key()
 
         # Import here to avoid import errors if SDK not installed
         try:
@@ -106,6 +105,7 @@ This iterative approach will help you solve the puzzle more accurately.
         # - No file writes, no web access, no bash - safe for benchmarking
         options = self._ClaudeAgentOptions(
             model=self.model_config.model_name,
+            env={"ANTHROPIC_API_KEY": self._api_key},
             allowed_tools=[
                 "TodoWrite",  # In-memory scratchpad
                 "Write", "Read", "Edit",  # File-based scratchpad for a /tmp/* entry per task

--- a/src/arc_agi_benchmarking/adapters/codexcli.py
+++ b/src/arc_agi_benchmarking/adapters/codexcli.py
@@ -42,18 +42,9 @@ Web search is disabled.
     def init_client(self):
         """
         Initialize the Codex CLI adapter.
-        Requires OPENAI_API_KEY (or api_key/openai_api_key in model kwargs).
+        The configured key is forwarded to the CLI process.
         """
-        api_key = (
-            self.model_config.kwargs.get("openai_api_key")
-            or self.model_config.kwargs.get("api_key")
-            or os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("CODEX_API_KEY")
-        )
-        if not api_key:
-            raise ValueError(
-                "OPENAI_API_KEY not found in environment variables (or api_key/openai_api_key in model config)"
-            )
+        self.get_api_key()
         return None
 
     def make_prediction(
@@ -157,15 +148,9 @@ Web search is disabled.
         self._apply_cli_options(args, working_directory=working_directory)
 
         env = os.environ.copy()
-        api_key = (
-            self.model_config.kwargs.get("openai_api_key")
-            or self.model_config.kwargs.get("api_key")
-            or os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("CODEX_API_KEY")
-        )
-        if api_key:
-            env["OPENAI_API_KEY"] = api_key
-            env["CODEX_API_KEY"] = api_key
+        api_key = self.get_api_key()
+        env["OPENAI_API_KEY"] = api_key
+        env["CODEX_API_KEY"] = api_key
         if "base_url" in self.model_config.kwargs:
             env["OPENAI_BASE_URL"] = self.model_config.kwargs["base_url"]
         env.setdefault("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "arc_agi_benchmarking_codexcli")

--- a/src/arc_agi_benchmarking/adapters/dashscope.py
+++ b/src/arc_agi_benchmarking/adapters/dashscope.py
@@ -13,10 +13,6 @@ class DashScopeAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for DashScope API."""
-        api_key = os.environ.get("DASHSCOPE_API_KEY")
-        if not api_key:
-            raise ValueError("DASHSCOPE_API_KEY not found in environment variables")
-
         # Use international endpoint by default
         # China: https://dashscope.aliyuncs.com/compatible-mode/v1
         # Singapore: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
@@ -25,4 +21,4 @@ class DashScopeAdapter(OpenAIBaseAdapter):
             "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         )
 
-        return OpenAI(api_key=api_key, base_url=base_url)
+        return OpenAI(api_key=self.get_api_key(), base_url=base_url)

--- a/src/arc_agi_benchmarking/adapters/deepseek.py
+++ b/src/arc_agi_benchmarking/adapters/deepseek.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -8,8 +7,4 @@ class DeepseekAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Deepseek."""
-        api_key = os.environ.get("DEEPSEEK_API_KEY")
-        if not api_key:
-            raise ValueError("DEEPSEEK_API_KEY not found in environment variables")
-
-        return OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.deepseek.com")

--- a/src/arc_agi_benchmarking/adapters/fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/fireworks.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Dict, Any
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter, _filter_api_kwargs
@@ -12,11 +11,7 @@ class FireworksAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Fireworks."""
-        api_key = os.environ.get("FIREWORKS_API_KEY")
-        if not api_key:
-            raise ValueError("FIREWORKS_API_KEY not found in environment variables")
-
-        return OpenAI(api_key=api_key, base_url="https://api.fireworks.ai/inference/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.fireworks.ai/inference/v1")
 
     def _chat_completion(self, messages: List[Dict[str, str]]) -> Any:
         api_kwargs = _filter_api_kwargs(self.model_config.kwargs)

--- a/src/arc_agi_benchmarking/adapters/gemini.py
+++ b/src/arc_agi_benchmarking/adapters/gemini.py
@@ -1,5 +1,4 @@
 from .provider import ProviderAdapter
-import os
 import json
 from google import genai
 from google.genai import types
@@ -19,13 +18,9 @@ class _StreamResponse:
 class GeminiAdapter(ProviderAdapter):
     def init_client(self):
         """Initialize the Gemini client."""
-        api_key = os.environ.get("GOOGLE_API_KEY")
-        if not api_key:
-            raise ValueError("GOOGLE_API_KEY not found in environment variables")
-        
         self.generation_config_dict = self.model_config.kwargs
         
-        client = genai.Client(api_key=api_key)
+        client = genai.Client(api_key=self.get_api_key())
         return client
 
     def make_prediction(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:

--- a/src/arc_agi_benchmarking/adapters/grok.py
+++ b/src/arc_agi_benchmarking/adapters/grok.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -8,8 +7,4 @@ class GrokAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Grok API."""
-        api_key = os.environ.get("XAI_API_KEY")
-        if not api_key:
-            raise ValueError("XAI_API_KEY not found in environment variables")
-
-        return OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.x.ai/v1")

--- a/src/arc_agi_benchmarking/adapters/groq.py
+++ b/src/arc_agi_benchmarking/adapters/groq.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -8,8 +7,4 @@ class GroqAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Groq."""
-        api_key = os.environ.get("GROQ_API_KEY")
-        if not api_key:
-            raise ValueError("GROQ_API_KEY not found in environment variables")
-
-        return OpenAI(api_key=api_key, base_url="https://api.groq.com/openai/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.groq.com/openai/v1")

--- a/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
@@ -1,5 +1,4 @@
 from .provider import ProviderAdapter
-import os
 import json
 from huggingface_hub import InferenceClient
 from datetime import datetime
@@ -14,12 +13,9 @@ class HuggingFaceFireworksAdapter(ProviderAdapter):
         """
         Initialize the Hugging Face Fireworks model
         """
-        if not os.environ.get("HUGGING_FACE_API_KEY"):
-            raise ValueError("HUGGING_FACE_API_KEY not found in environment variables")
-        
         client = InferenceClient(
             provider="fireworks-ai",
-            api_key=os.environ.get("HUGGING_FACE_API_KEY")
+            api_key=self.get_api_key()
         )
         return client
 

--- a/src/arc_agi_benchmarking/adapters/mulerouter.py
+++ b/src/arc_agi_benchmarking/adapters/mulerouter.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -8,10 +7,7 @@ class MuleRouterAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for MuleRouter API."""
-        api_key = os.environ.get("MULEROUTER_API_KEY")
-        if not api_key:
-            raise ValueError("MULEROUTER_API_KEY not found in environment variables")
-
         return OpenAI(
-            api_key=api_key, base_url="https://api.mulerouter.ai/vendors/openai/v1"
+            api_key=self.get_api_key(),
+            base_url="https://api.mulerouter.ai/vendors/openai/v1",
         )

--- a/src/arc_agi_benchmarking/adapters/open_ai.py
+++ b/src/arc_agi_benchmarking/adapters/open_ai.py
@@ -9,11 +9,14 @@ class OpenAIAdapter(OpenAIBaseAdapter):
     def init_client(self):
         """Initialize the OpenAI client.
 
-        Honors optional `base_url` and `api_key_env` from the model config so the
-        OpenAI adapter can target any OpenAI-compatible endpoint. Defaults preserve
-        the standard OpenAI behavior (OPENAI_API_KEY + default base URL).
+        Honors `base_url` and `api_key_env` from the model config so the OpenAI
+        adapter can target OpenAI or any OpenAI-compatible endpoint without
+        assuming which credential should be used.
         """
-        api_key_env = self.model_config.api_key_env or "OPENAI_API_KEY"
+        api_key_env = self.model_config.api_key_env
+        if not api_key_env:
+            raise ValueError("api_key_env must be configured for the OpenAI adapter")
+
         api_key = os.environ.get(api_key_env)
         if not api_key:
             raise ValueError(f"{api_key_env} not found in environment variables")

--- a/src/arc_agi_benchmarking/adapters/open_ai.py
+++ b/src/arc_agi_benchmarking/adapters/open_ai.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -13,15 +12,7 @@ class OpenAIAdapter(OpenAIBaseAdapter):
         adapter can target OpenAI or any OpenAI-compatible endpoint without
         assuming which credential should be used.
         """
-        api_key_env = self.model_config.api_key_env
-        if not api_key_env:
-            raise ValueError("api_key_env must be configured for the OpenAI adapter")
-
-        api_key = os.environ.get(api_key_env)
-        if not api_key:
-            raise ValueError(f"{api_key_env} not found in environment variables")
-
-        client_kwargs = {"api_key": api_key, "max_retries": 0, "timeout": 1800}
+        client_kwargs = {"api_key": self.get_api_key(), "max_retries": 0, "timeout": 1800}
         if self.model_config.base_url:
             client_kwargs["base_url"] = self.model_config.base_url
 

--- a/src/arc_agi_benchmarking/adapters/openrouter.py
+++ b/src/arc_agi_benchmarking/adapters/openrouter.py
@@ -1,4 +1,3 @@
-import os
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
 
@@ -8,8 +7,4 @@ class OpenRouterAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for OpenRouter API."""
-        api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not api_key:
-            raise ValueError("OPENROUTER_API_KEY not found in environment variables")
-
-        return OpenAI(api_key=api_key, base_url="https://openrouter.ai/api/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://openrouter.ai/api/v1")

--- a/src/arc_agi_benchmarking/adapters/provider.py
+++ b/src/arc_agi_benchmarking/adapters/provider.py
@@ -1,4 +1,5 @@
 import abc
+import os
 from typing import List, Dict, Tuple, Any, Optional
 import json
 from datetime import datetime
@@ -23,6 +24,19 @@ class ProviderAdapter(abc.ABC):
         
         # Initialize the client
         self.client = self.init_client()
+
+    def get_api_key(self) -> str:
+        """Read the API key named by this model configuration."""
+        api_key_env = self.model_config.api_key_env
+        if not api_key_env:
+            raise ValueError(
+                f"api_key_env must be configured for provider '{self.model_config.provider}'"
+            )
+
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            raise ValueError(f"{api_key_env} not found in environment variables")
+        return api_key
 
     @abc.abstractmethod
     def init_client(self):

--- a/src/arc_agi_benchmarking/adapters/together.py
+++ b/src/arc_agi_benchmarking/adapters/together.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -35,11 +34,7 @@ class TogetherAdapter(ProviderAdapter):
     """Adapter boundary for the official Together SDK."""
 
     def init_client(self):
-        api_key = os.environ.get("TOGETHER_API_KEY")
-        if not api_key:
-            raise ValueError("TOGETHER_API_KEY not found in environment variables")
-
-        return Together(api_key=api_key)
+        return Together(api_key=self.get_api_key())
 
     def _call_together_model(self, prompt: str) -> Any:
         api_kwargs = _filter_api_kwargs(self.model_config.kwargs)

--- a/src/arc_agi_benchmarking/adapters/xai.py
+++ b/src/arc_agi_benchmarking/adapters/xai.py
@@ -1,4 +1,3 @@
-import os
 import httpx
 from openai import OpenAI
 from .openai_base import OpenAIBaseAdapter
@@ -9,12 +8,8 @@ class XAIAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for XAI API."""
-        api_key = os.environ.get("XAI_API_KEY")
-        if not api_key:
-            raise ValueError("XAI_API_KEY not found in environment variables")
-
         return OpenAI(
-            api_key=api_key,
+            api_key=self.get_api_key(),
             base_url="https://api.x.ai/v1",
             timeout=httpx.Timeout(3600, connect=30)
         )

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -52,6 +52,7 @@ models:
   - name: "gpt-5-2-pro-2025-12-11-medium"
     model_name: "gpt-5.2-pro-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -66,6 +67,7 @@ models:
   - name: "gpt-5-2-pro-2025-12-11-high"
     model_name: "gpt-5.2-pro-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -80,6 +82,7 @@ models:
   - name: "gpt-5-2-pro-2025-12-11-xhigh"
     model_name: "gpt-5.2-pro-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     # reasoning:
@@ -93,6 +96,7 @@ models:
   - name: "gpt-5-2-2025-12-11-thinking-xhigh"
     model_name: "gpt-5.2-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -107,6 +111,7 @@ models:
   - name: "gpt-5-2-2025-12-11-thinking-high"
     model_name: "gpt-5.2-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -121,6 +126,7 @@ models:
   - name: "gpt-5-2-2025-12-11-thinking-medium"
     model_name: "gpt-5.2-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -135,6 +141,7 @@ models:
   - name: "gpt-5-2-2025-12-11-thinking-low"
     model_name: "gpt-5.2-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -149,6 +156,7 @@ models:
   - name: "gpt-5-2-2025-12-11-thinking-none"
     model_name: "gpt-5.2-2025-12-11"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -163,6 +171,7 @@ models:
   - name: "gpt-5-1-2025-11-13-thinking-high"
     model_name: "gpt-5.1-2025-11-13"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -177,6 +186,7 @@ models:
   - name: "gpt-5-1-2025-11-13-thinking-medium"
     model_name: "gpt-5.1-2025-11-13"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -191,6 +201,7 @@ models:
   - name: "gpt-5-1-2025-11-13-thinking-low"
     model_name: "gpt-5.1-2025-11-13"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -205,6 +216,7 @@ models:
   - name: "gpt-5-1-2025-11-13-thinking-none"
     model_name: "gpt-5.1-2025-11-13"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -219,6 +231,7 @@ models:
   - name: "gpt-5-pro-2025-10-06"
     model_name: "gpt-5-pro-2025-10-06"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     reasoning:
@@ -232,6 +245,7 @@ models:
   - name: "gpt-5-2025-08-07-high"
     model_name: "gpt-5-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -246,6 +260,7 @@ models:
   - name: "gpt-5-2025-08-07-medium"
     model_name: "gpt-5-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -259,6 +274,7 @@ models:
   - name: "gpt-5-2025-08-07-low"
     model_name: "gpt-5-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -272,6 +288,7 @@ models:
   - name: "gpt-5-2025-08-07-minimal"
     model_name: "gpt-5-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "minimal"
@@ -285,6 +302,7 @@ models:
   - name: "gpt-5-mini-2025-08-07-high"
     model_name: "gpt-5-mini-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -299,6 +317,7 @@ models:
   - name: "gpt-5-mini-2025-08-07-medium"
     model_name: "gpt-5-mini-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -313,6 +332,7 @@ models:
   - name: "gpt-5-mini-2025-08-07-low"
     model_name: "gpt-5-mini-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -326,6 +346,7 @@ models:
   - name: "gpt-5-mini-2025-08-07-minimal"
     model_name: "gpt-5-mini-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "minimal"
@@ -339,6 +360,7 @@ models:
   - name: "gpt-5-nano-2025-08-07-high"
     model_name: "gpt-5-nano-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -353,6 +375,7 @@ models:
   - name: "gpt-5-nano-2025-08-07-medium"
     model_name: "gpt-5-nano-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -367,6 +390,7 @@ models:
   - name: "gpt-5-nano-2025-08-07-low"
     model_name: "gpt-5-nano-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -381,6 +405,7 @@ models:
   - name: "gpt-5-nano-2025-08-07-minimal"
     model_name: "gpt-5-nano-2025-08-07"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "minimal"
@@ -394,6 +419,7 @@ models:
   - name: "o3-pro-2025-06-10-high"
     model_name: "o3-pro-2025-06-10"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -407,6 +433,7 @@ models:
   - name: "o3-pro-2025-06-10-medium"
     model_name: "o3-pro-2025-06-10"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -420,6 +447,7 @@ models:
   - name: "o3-pro-2025-06-10-low"
     model_name: "o3-pro-2025-06-10"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -433,6 +461,7 @@ models:
   - name: "codex-mini-latest"
     model_name: "codex-mini-latest"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     max_completion_tokens: 100000
     pricing:
@@ -443,6 +472,7 @@ models:
   - name: "gpt-5-1-codex-mini-openai"
     model_name: "gpt-5.1-codex-mini"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     background: true
     max_completion_tokens: 100000
@@ -475,6 +505,7 @@ models:
   - name: "o3-2025-04-16-high"
     model_name: "o3-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -488,6 +519,7 @@ models:
   - name: "o3-2025-04-16-medium"
     model_name: "o3-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -502,6 +534,7 @@ models:
   - name: "o3-2025-04-16-low-2025-06-10"
     model_name: "o3-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -516,6 +549,7 @@ models:
   - name: "o3-2025-04-16-low"
     model_name: "o3-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     reasoning_effort: "low"
     max_completion_tokens: 100000
     pricing:
@@ -526,6 +560,7 @@ models:
   - name: "o4-mini-2025-04-16-high"
     model_name: "o4-mini-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -539,6 +574,7 @@ models:
   - name: "o4-mini-2025-04-16-medium"
     model_name: "o4-mini-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     reasoning_effort: "medium"
     max_completion_tokens: 100000
     pricing:
@@ -549,6 +585,7 @@ models:
   - name: "o4-mini-2025-04-16-low"
     model_name: "o4-mini-2025-04-16"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     reasoning_effort: "low"
     max_completion_tokens: 100000
     pricing:
@@ -559,6 +596,7 @@ models:
   - name: "gpt-4-1-nano-2025-04-14"
     model_name: "gpt-4.1-nano-2025-04-14"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 10000
     pricing:
       date: "2025-04-14"
@@ -568,6 +606,7 @@ models:
   - name: "gpt-4-1-mini-2025-04-14"
     model_name: "gpt-4.1-mini-2025-04-14"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 10000
     pricing:
       date: "2025-04-14"
@@ -577,6 +616,7 @@ models:
   - name: "gpt-4-1-2025-04-14"
     model_name: "gpt-4.1-2025-04-14"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 10000
     pricing:
       date: "2025-04-14"
@@ -586,6 +626,7 @@ models:
   - name: "gpt-4o-2024-11-20"
     model_name: "gpt-4o-2024-11-20"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     max_completion_tokens: 8000
     stream: true
@@ -597,6 +638,7 @@ models:
   - name: "gpt-4o-2024-05-13"
     model_name: "gpt-4o-2024-05-13"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     max_completion_tokens: 4096
     pricing:
@@ -608,6 +650,7 @@ models:
   - name: "gpt-4o-mini-2024-07-18"
     model_name: "gpt-4o-mini-2024-07-18"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     max_completion_tokens: 8000
     pricing:
@@ -618,6 +661,7 @@ models:
   - name: "gpt-4-5-preview-2025-02-27"
     model_name: "gpt-4.5-preview-2025-02-27"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 10000
     pricing:
       date: "2025-03-15"
@@ -627,6 +671,7 @@ models:
   - name: "o3-mini-2025-01-31-high"
     model_name: "o3-mini-2025-01-31"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 100000
     reasoning_effort: "high"
     pricing:
@@ -637,6 +682,7 @@ models:
   - name: "o3-mini-2025-01-31-medium"
     model_name: "o3-mini-2025-01-31"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 100000
     reasoning_effort: "medium"
     pricing:
@@ -647,6 +693,7 @@ models:
   - name: "o3-mini-2025-01-31-low"
     model_name: "o3-mini-2025-01-31"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 100000
     reasoning_effort: "low"
     pricing:
@@ -657,6 +704,7 @@ models:
   - name: "o1-2024-12-17-low"
     model_name: "o1-2024-12-17"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 75000
     reasoning_effort: "low"
     pricing:
@@ -667,6 +715,7 @@ models:
   - name: "o1-2024-12-17-medium"
     model_name: "o1-2024-12-17"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 75000
     reasoning_effort: "medium"
     pricing:
@@ -677,6 +726,7 @@ models:
   - name: "o1-2024-12-17-high"
     model_name: "o1-2024-12-17"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 75000
     reasoning_effort: "high"
     pricing:
@@ -687,6 +737,7 @@ models:
   - name: "o1-pro-2025-03-19-high"
     model_name: "o1-pro-2025-03-19"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "high"
@@ -701,6 +752,7 @@ models:
   - name: "o1-pro-2025-03-19-medium"
     model_name: "o1-pro-2025-03-19"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "medium"
@@ -715,6 +767,7 @@ models:
   - name: "o1-pro-2025-03-19-low"
     model_name: "o1-pro-2025-03-19"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     reasoning:
       effort: "low"
@@ -729,6 +782,7 @@ models:
   - name: "gpt4o_mini"
     model_name: "gpt-4o-mini"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     api_type: "responses"
     max_completion_tokens: 10000
     pricing:
@@ -739,6 +793,7 @@ models:
   - name: "gpt-4.5-2025-02-21-alpha"
     model_name: "gpt-4.5-2025-02-21-alpha"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 4024
     pricing:
       date: "2025-02-23"
@@ -748,6 +803,7 @@ models:
   - name: "o1-preview-2024-09-12"
     model_name: "o1-preview-2024-09-12"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 32768
     pricing:
       date: "2025-04-28"
@@ -757,6 +813,7 @@ models:
   - name: "o1-mini-2024-09-12"
     model_name: "o1-mini-2024-09-12"
     provider: "openai"
+    api_key_env: "OPENAI_API_KEY"
     max_completion_tokens: 65536
     pricing:
       date: "2025-04-28"

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -37,6 +37,7 @@ models:
   - name: "deepseek-v4-pro-together"
     model_name: "deepseek-ai/DeepSeek-V4-Pro"
     provider: "together"
+    api_key_env: "TOGETHER_API_KEY"
     api_type: "chat_completions"
     temperature: 0
     max_tokens: 8192
@@ -484,6 +485,7 @@ models:
   - name: "gpt-5-1-codex-max-codexcli"
     model_name: "gpt-5.1-codex-max"
     provider: "codexcli"
+    api_key_env: "OPENAI_API_KEY"
     sandbox_mode: "workspace-write"
     approval_policy: "never"
     pricing:
@@ -495,6 +497,7 @@ models:
   - name: "gpt-5-1-codex-mini-codexcli"
     model_name: "gpt-5.1-codex-mini"
     provider: "codexcli"
+    api_key_env: "OPENAI_API_KEY"
     sandbox_mode: "workspace-write"
     approval_policy: "never"
     pricing:
@@ -827,6 +830,7 @@ models:
   - name: "grok-4-fast-reasoning"
     model_name: "grok-4-fast-reasoning"
     provider: "grok"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 200000
     stream: true
     pricing:
@@ -837,6 +841,7 @@ models:
   - name: "grok-3-mini-beta"
     model_name: "grok-3-mini-beta"
     provider: "grok"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 8192 # Assuming same context as grok-3-beta, adjust if needed
     pricing:
       date: "2025-04-28"
@@ -846,6 +851,7 @@ models:
   - name: "grok-3-mini-beta-high"
     model_name: "grok-3-mini-beta"
     provider: "grok"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 100000 # Assuming same context as grok-3-beta, adjust if needed
     reasoning_effort: "high"
     pricing:
@@ -856,6 +862,7 @@ models:
   - name: "grok-3-beta"
     model_name: "grok-3-beta"
     provider: "grok"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 8192
     pricing:
       date: "2025-04-22"
@@ -866,6 +873,7 @@ models:
   - name: "grok-3-openrouter"
     model_name: "x-ai/grok-beta"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 100000
     pricing:
       date: "2025-04-22"
@@ -875,6 +883,7 @@ models:
   - name: "grok-3-mini-beta-low-openrouter"
     model_name: "x-ai/grok-3-mini-beta"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 100000
     extra_body:
       reasoning:
@@ -887,6 +896,7 @@ models:
   - name: "grok-3-mini-beta-high-openrouter"
     model_name: "x-ai/grok-3-mini-beta"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 100000
     extra_body:
       reasoning:
@@ -903,6 +913,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-64k"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -916,6 +927,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-32k"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -929,6 +941,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-16k"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -942,6 +955,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-8k"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -955,6 +969,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-1k"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     thinking:
       type: "enabled"
@@ -968,6 +983,7 @@ models:
   - name: "claude-opus-4-5-20251101-thinking-none"
     model_name: "claude-opus-4-5-20251101"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     pricing:
@@ -978,6 +994,7 @@ models:
   - name: "claude-haiku-4-5-20251001-thinking-32k"
     model_name: "claude-haiku-4-5-20251001"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -991,6 +1008,7 @@ models:
   - name: "claude-haiku-4-5-20251001-thinking-16k"
     model_name: "claude-haiku-4-5-20251001"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1004,6 +1022,7 @@ models:
   - name: "claude-haiku-4-5-20251001-thinking-8k"
     model_name: "claude-haiku-4-5-20251001"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1017,6 +1036,7 @@ models:
   - name: "claude-haiku-4-5-20251001-thinking-1k"
     model_name: "claude-haiku-4-5-20251001"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1030,6 +1050,7 @@ models:
   - name: "claude-haiku-4-5-20251001"
     model_name: "claude-haiku-4-5-20251001"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     pricing:
@@ -1040,6 +1061,7 @@ models:
   - name: "claude-sonnet-4-5-20250929-thinking-32k"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1053,6 +1075,7 @@ models:
   - name: "claude-sonnet-4-5-20250929-thinking-16k"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1066,6 +1089,7 @@ models:
   - name: "claude-sonnet-4-5-20250929-thinking-8k"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1079,6 +1103,7 @@ models:
   - name: "claude-sonnet-4-5-20250929-thinking-1k"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     thinking:
@@ -1092,6 +1117,7 @@ models:
   - name: "claude-sonnet-4-5-20250929"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 64000
     stream: true
     pricing:
@@ -1102,6 +1128,7 @@ models:
   - name: "claude-4-sonnet-20250522-thinking-8k-bedrock"
     model_name: "anthropic/claude-sonnet-4"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 32000
     extra_body:
       provider:
@@ -1117,6 +1144,7 @@ models:
   - name: "claude-3-7-sonnet-20250219"
     model_name: "claude-3-7-sonnet-20250219"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 8192
     pricing:
       date: "2025-03-12"
@@ -1126,6 +1154,7 @@ models:
   - name: "claude-3-7-sonnet-20250219-thinking-1k"
     model_name: "claude-3-7-sonnet-20250219"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 20000
     thinking:
       type: "enabled"
@@ -1138,6 +1167,7 @@ models:
   - name: "claude-3-7-sonnet-20250219-thinking-8k"
     model_name: "claude-3-7-sonnet-20250219"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 20000
     thinking:
       type: "enabled"
@@ -1150,6 +1180,7 @@ models:
   - name: "claude-3-7-sonnet-20250219-thinking-16k"
     model_name: "claude-3-7-sonnet-20250219"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 21000
     thinking:
       type: "enabled"
@@ -1162,6 +1193,7 @@ models:
   - name: "claude-3-5-sonnet-20241022"
     model_name: "claude-3-5-sonnet-20241022"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 4024
     temperature: 0.0
     pricing:
@@ -1172,6 +1204,7 @@ models:
   - name: "claude_haiku"
     model_name: "claude-3-5-haiku-latest"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 4024
     temperature: 0.0
     pricing:
@@ -1182,6 +1215,7 @@ models:
   - name: "claude_opus"
     model_name: "claude-3-opus-latest"
     provider: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
     max_tokens: 4024
     temperature: 0.0
     pricing:
@@ -1196,6 +1230,7 @@ models:
   - name: "claude-opus-4-5-20251101-claudeagentsdk"
     model_name: "claude-opus-4-5-20251101"
     provider: "claudeagentsdk"
+    api_key_env: "ANTHROPIC_API_KEY"
     pricing:
       date: "2026-01-02"
       input: 5.00
@@ -1204,6 +1239,7 @@ models:
   - name: "claude-sonnet-4-5-20250929-claudeagentsdk"
     model_name: "claude-sonnet-4-5-20250929"
     provider: "claudeagentsdk"
+    api_key_env: "ANTHROPIC_API_KEY"
     pricing:
       date: "2026-01-02"
       input: 3.00
@@ -1212,6 +1248,7 @@ models:
   - name: "claude-haiku-4-5-20251001-claudeagentsdk"
     model_name: "claude-haiku-4-5-20251001"
     provider: "claudeagentsdk"
+    api_key_env: "ANTHROPIC_API_KEY"
     pricing:
       date: "2026-01-02"
       input: 1.00
@@ -1224,6 +1261,7 @@ models:
   - name: "gemini-3-flash-preview-thinking-high"
     model_name: "models/gemini-3-flash-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "HIGH"
@@ -1237,6 +1275,7 @@ models:
   - name: "gemini-3-flash-preview-thinking-low"
     model_name: "models/gemini-3-flash-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "LOW"
@@ -1250,6 +1289,7 @@ models:
   - name: "gemini-3-flash-preview-thinking-minimal"
     model_name: "models/gemini-3-flash-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "MINIMAL"
@@ -1263,6 +1303,7 @@ models:
   - name: "gemini-3-pro-preview-thinking-high"
     model_name: "models/gemini-3-pro-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "high"
@@ -1276,6 +1317,7 @@ models:
   - name: "gemini-3-pro-preview-thinking-medium"
     model_name: "models/gemini-3-pro-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "medium"
@@ -1289,6 +1331,7 @@ models:
   - name: "gemini-3-pro-preview-thinking-low"
     model_name: "models/gemini-3-pro-preview"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 64000
     thinking_config:
       thinking_level: "low"
@@ -1302,6 +1345,7 @@ models:
   - name: "gemini-3-pro-preview"
     model_name: "google/gemini-3-pro-preview"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 64000
     pricing:
       date: "2025-11-13"
@@ -1311,6 +1355,7 @@ models:
   - name: "gemini-2-5-flash-preview-05-20"
     model_name: "gemini-2.5-flash-preview-05-20"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65536
     automatic_function_calling:
       disable: true
@@ -1322,6 +1367,7 @@ models:
   - name: "gemini-2-5-flash-preview-05-20-thinking-1k"
     model_name: "gemini-2.5-flash-preview-05-20"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65536
     thinking_config:
       thinking_budget: 1024
@@ -1335,6 +1381,7 @@ models:
   - name: "gemini-2-5-flash-preview-05-20-thinking-8k"
     model_name: "gemini-2.5-flash-preview-05-20"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65536
     thinking_config:
       thinking_budget: 8000
@@ -1348,6 +1395,7 @@ models:
   - name: "gemini-2-5-flash-preview-05-20-thinking-16k"
     model_name: "gemini-2.5-flash-preview-05-20"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65536
     thinking_config:
       thinking_budget: 16000
@@ -1361,6 +1409,7 @@ models:
   - name: "gemini-2-5-flash-preview-05-20-thinking-24k"
     model_name: "gemini-2.5-flash-preview-05-20"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65536
     thinking_config:
       thinking_budget: 24576
@@ -1374,6 +1423,7 @@ models:
   - name: "gemini-2-0-flash-001"
     model_name: "gemini-2.0-flash-001"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 4024
     pricing:
       date: "2025-02-23"
@@ -1383,6 +1433,7 @@ models:
   - name: "gemini-1-5-pro-002"
     model_name: "gemini-1.5-pro-002"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 4024
     pricing:
       date: "2025-02-23"
@@ -1392,6 +1443,7 @@ models:
   - name: "gemini-2.5-pro-exp-03-25"
     model_name: "gemini-2.5-pro-exp-03-25"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 200000
     pricing:
       date: "2025-03-25"
@@ -1401,6 +1453,7 @@ models:
   - name: "gemini-2-5-pro-preview-05-06"
     model_name: "gemini-2.5-pro-preview-05-06"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65535
     pricing:
       date: "2025-05-29"
@@ -1410,6 +1463,7 @@ models:
   - name: "gemini-2-5-pro-preview-05-06-thinking-1k"
     model_name: "gemini-2.5-pro-preview-05-06"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65535
     thinking_config:
       thinking_budget: 1000
@@ -1423,6 +1477,7 @@ models:
   - name: "gemini-2-5-pro-preview-05-06-thinking-8k"
     model_name: "gemini-2.5-pro-preview-05-06"
     provider: "gemini"
+    api_key_env: "GOOGLE_API_KEY"
     max_output_tokens: 65535
     thinking_config:
       thinking_budget: 8000
@@ -1437,6 +1492,7 @@ models:
   - name: "gemini-2-5-pro-preview-openrouter"
     model_name: "google/gemini-2.5-pro-preview"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 65535
     pricing:
       date: "2025-05-29"
@@ -1446,6 +1502,7 @@ models:
   - name: "gemini-2-5-pro-preview-openrouter-thinking-1k"
     model_name: "google/gemini-2.5-pro-preview"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 65535
     extra_body:
       provider:
@@ -1465,6 +1522,7 @@ models:
   - name: "magistral-small-2506"
     model_name: "mistralai/magistral-small-2506"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 32000 # Max is 40,000. Leaving cushion for prompt
     pricing:
       date: "2025-06-12"
@@ -1474,6 +1532,7 @@ models:
   - name: "magistral-medium-2506"
     model_name: "mistralai/magistral-medium-2506"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 32000 # Max is 40,000. Leaving cushion for prompt
     pricing:
       date: "2025-06-12"
@@ -1483,6 +1542,7 @@ models:
   - name: "magistral-medium-2506-thinking"
     model_name: "mistralai/magistral-medium-2506:thinking"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 32000 # Max is 40,000. Leaving cushion for prompt
     pricing:
       date: "2025-06-12"
@@ -1496,6 +1556,7 @@ models:
   - name: "deepseek_chat"
     model_name: "deepseek-chat"
     provider: "deepseek"
+    api_key_env: "DEEPSEEK_API_KEY"
     max_tokens: 4024
     temperature: 0.0
     pricing:
@@ -1506,6 +1567,7 @@ models:
   - name: "deepseek_r1"
     model_name: "deepseek-reasoner"
     provider: "deepseek"
+    api_key_env: "DEEPSEEK_API_KEY"
     max_completion_tokens: 8000
     pricing:
       date: "2025-02-23"
@@ -1515,6 +1577,7 @@ models:
   - name: "deepseek_r1_0528-openrouter"
     model_name: "deepseek/deepseek-r1-0528"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 130000 # Max is 163,840, leaving lots of room for prompt
     pricing:
       date: "2025-05-28"
@@ -1528,6 +1591,7 @@ models:
   - name: "QwQ-32B"
     model_name: "Qwen/QwQ-32B"
     provider: "huggingfacefireworks"
+    api_key_env: "HUGGING_FACE_API_KEY"
     max_tokens: 32768 # From HF example
     pricing:
       date: "2025-03-05"
@@ -1537,6 +1601,7 @@ models:
   - name: "QwQ-32B-Fireworks"
     model_name: "accounts/fireworks/models/qwq-32b"
     provider: "fireworks"
+    api_key_env: "FIREWORKS_API_KEY"
     max_tokens: 32768 # From HF example
     pricing:
       date: "2025-03-05"
@@ -1550,6 +1615,7 @@ models:
   - name: "deepseek-r1-fireworks"
     model_name: "accounts/fireworks/models/deepseek-r1"
     provider: "fireworks"
+    api_key_env: "FIREWORKS_API_KEY"
     max_tokens: 32768 # From HF example
     pricing:
       date: "2025-03-05"
@@ -1559,6 +1625,7 @@ models:
   - name: "deepseek-v3-20250324-fireworks"
     model_name: "accounts/fireworks/models/deepseek-v3-0324"
     provider: "fireworks"
+    api_key_env: "FIREWORKS_API_KEY"
     max_tokens: 32768 # From HF example
     pricing:
       date: "2025-03-24"
@@ -1572,6 +1639,7 @@ models:
   - name: "grok-4-0709"
     model_name: "grok-4-0709"
     provider: "xai"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 128000
     temperature: 0.7
     top_p: 1.0
@@ -1584,6 +1652,7 @@ models:
   - name: "grok-3-mini-xai-high"
     model_name: "grok-3-mini"
     provider: "xai"
+    api_key_env: "XAI_API_KEY"
     max_completion_tokens: 100000
     reasoning_effort: "high"
     temperature: 0.7
@@ -1601,6 +1670,7 @@ models:
   - name: "kimi-k2.5"
     model_name: "accounts/fireworks/models/kimi-k2p5"
     provider: "fireworks"
+    api_key_env: "FIREWORKS_API_KEY"
     max_tokens: 100000
     pricing:
       date: "2025-01-27"
@@ -1610,6 +1680,7 @@ models:
   - name: "qwen3-max-thinking-openrouter"
     model_name: "qwen/qwen3-max-thinking"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 32768
     pricing:
       date: "2026-02-10"
@@ -1619,6 +1690,7 @@ models:
   - name: "qwen3-235b-a22b-07-25"
     model_name: "qwen/qwen3-235b-a22b-07-25"
     provider: "openrouter"
+    api_key_env: "OPENROUTER_API_KEY"
     max_tokens: 100000
     pricing:
       date: "2025-07-21"
@@ -1628,6 +1700,7 @@ models:
   - name: "qwen3-235b-a22b-instruct-2507"
     model_name: "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
     provider: "fireworks"
+    api_key_env: "FIREWORKS_API_KEY"
     max_tokens: 100000
     pricing:
       date: "2025-07-21"
@@ -1641,6 +1714,7 @@ models:
   - name: "qwen3-max-thinking"
     model_name: "qwen3-max-2026-01-23"
     provider: "dashscope"
+    api_key_env: "DASHSCOPE_API_KEY"
     max_tokens: 65536
     extra_body:
       enable_thinking: true
@@ -1655,6 +1729,7 @@ models:
   - name: "qwen3-max"
     model_name: "qwen-max-latest"
     provider: "dashscope"
+    api_key_env: "DASHSCOPE_API_KEY"
     max_tokens: 65536
     rate_limit:
       rate: 20
@@ -1667,6 +1742,7 @@ models:
   - name: "qwen-plus"
     model_name: "qwen-plus-latest"
     provider: "dashscope"
+    api_key_env: "DASHSCOPE_API_KEY"
     max_tokens: 131072
     rate_limit:
       rate: 30
@@ -1679,6 +1755,7 @@ models:
   - name: "qwen-turbo"
     model_name: "qwen-turbo-latest"
     provider: "dashscope"
+    api_key_env: "DASHSCOPE_API_KEY"
     max_tokens: 1000000
     rate_limit:
       rate: 50
@@ -1695,6 +1772,7 @@ models:
   - name: "mulerouter-qwen3-max"
     model_name: "qwen3-max"
     provider: "mulerouter"
+    api_key_env: "MULEROUTER_API_KEY"
     max_tokens: 65536
     rate_limit:
       rate: 20
@@ -1707,6 +1785,7 @@ models:
   - name: "mulerouter-qwen-plus"
     model_name: "qwen-plus"
     provider: "mulerouter"
+    api_key_env: "MULEROUTER_API_KEY"
     max_tokens: 131072
     rate_limit:
       rate: 30
@@ -1719,6 +1798,7 @@ models:
   - name: "mulerouter-qwen-flash"
     model_name: "qwen-flash"
     provider: "mulerouter"
+    api_key_env: "MULEROUTER_API_KEY"
     max_tokens: 131072
     rate_limit:
       rate: 50

--- a/src/arc_agi_benchmarking/schemas.py
+++ b/src/arc_agi_benchmarking/schemas.py
@@ -301,10 +301,10 @@ class ModelConfig(BaseModel):
         return values
 
     @model_validator(mode='after')
-    def require_openai_api_key_env(self):
-        """Require OpenAI adapter configs to name their API key explicitly."""
-        if self.provider == 'openai' and not self.api_key_env:
-            raise ValueError("api_key_env is required when provider is 'openai'")
+    def require_api_key_env(self):
+        """Require authenticated provider configs to name their API key."""
+        if self.provider != 'random' and not self.api_key_env:
+            raise ValueError("api_key_env is required unless provider is 'random'")
         return self
 
 

--- a/src/arc_agi_benchmarking/schemas.py
+++ b/src/arc_agi_benchmarking/schemas.py
@@ -300,6 +300,14 @@ class ModelConfig(BaseModel):
                     
         return values
 
+    @model_validator(mode='after')
+    def require_openai_api_key_env(self):
+        """Require OpenAI adapter configs to name their API key explicitly."""
+        if self.provider == 'openai' and not self.api_key_env:
+            raise ValueError("api_key_env is required when provider is 'openai'")
+        return self
+
+
 class ScoringResult(BaseModel):
     """
     Result of scoring a task, containing the score (accuracy), cost, and number of attempts.

--- a/src/arc_agi_benchmarking/tests/test_anthropic.py
+++ b/src/arc_agi_benchmarking/tests/test_anthropic.py
@@ -15,9 +15,24 @@ def mock_model_config():
         name="test-claude-model",
         model_name="claude-3-7-sonnet-20250219",
         provider="anthropic",
+        api_key_env="ANTHROPIC_API_KEY",
         pricing=ModelPricing(date="2025-03-12", input=3.0, output=15.0),
         kwargs={"max_tokens": 8192}
     )
+
+
+def test_init_client_uses_configured_api_key_env(mock_model_config, monkeypatch):
+    adapter = AnthropicAdapter.__new__(AnthropicAdapter)
+    adapter.model_config = mock_model_config.model_copy(
+        update={"api_key_env": "CUSTOM_ANTHROPIC_KEY"}
+    )
+    monkeypatch.setenv("CUSTOM_ANTHROPIC_KEY", "custom-anthropic-secret")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    with patch("arc_agi_benchmarking.adapters.anthropic.anthropic.Anthropic") as client:
+        adapter.init_client()
+
+    client.assert_called_once_with(api_key="custom-anthropic-secret")
 
 
 @pytest.fixture

--- a/src/arc_agi_benchmarking/tests/test_claudeagentsdk.py
+++ b/src/arc_agi_benchmarking/tests/test_claudeagentsdk.py
@@ -68,6 +68,7 @@ def mock_model_config():
         name="test-claudeagentsdk-model",
         model_name="claude-sonnet-4-5-20250929",
         provider="claudeagentsdk",
+        api_key_env="ANTHROPIC_API_KEY",
         pricing=ModelPricing(date="2026-01-02", input=1.0, output=5.0),
         kwargs={}
     )
@@ -81,6 +82,7 @@ def adapter_instance(mock_model_config):
             mock_init.return_value = None
             adapter = ClaudeagentsdkAdapter.__new__(ClaudeagentsdkAdapter)
             adapter.model_config = mock_model_config
+            adapter._api_key = "test-key"
             adapter._query = None  # Each test overrides this with a generator
             adapter._ClaudeAgentOptions = Mock(return_value=Mock())
             return adapter

--- a/src/arc_agi_benchmarking/tests/test_codexcli.py
+++ b/src/arc_agi_benchmarking/tests/test_codexcli.py
@@ -27,6 +27,7 @@ def mock_model_config(tmp_path):
         name="test-codexcli-model",
         model_name="codex-mini-latest",
         provider="codexcli",
+        api_key_env="OPENAI_API_KEY",
         pricing=ModelPricing(date="2025-05-16", input=2.0, output=4.0),
         kwargs={"scratchpad_root": str(tmp_path / "scratchpad")},
     )

--- a/src/arc_agi_benchmarking/tests/test_correct_field.py
+++ b/src/arc_agi_benchmarking/tests/test_correct_field.py
@@ -104,6 +104,7 @@ def mock_model_config():
         name="test_config",
         model_name="test-model",
         provider="test-provider",
+        api_key_env="TEST_API_KEY",
         pricing=ModelPricing(date="2024-01-01", input=1.0, output=2.0),
         kwargs={}
     )

--- a/src/arc_agi_benchmarking/tests/test_custom_base_url.py
+++ b/src/arc_agi_benchmarking/tests/test_custom_base_url.py
@@ -60,9 +60,13 @@ class TestCustomBaseUrlSchema:
         assert "base_url" not in config.kwargs
         assert "api_key_env" not in config.kwargs
 
-    def test_openai_config_requires_api_key_env(self):
+    def test_authenticated_config_requires_api_key_env(self):
         with pytest.raises(ValueError, match="api_key_env is required"):
             _make_config()
+
+    def test_random_config_does_not_require_api_key_env(self):
+        config = _make_config(provider="random")
+        assert config.api_key_env is None
 
 
 class TestCustomBaseUrlClientInit:

--- a/src/arc_agi_benchmarking/tests/test_custom_base_url.py
+++ b/src/arc_agi_benchmarking/tests/test_custom_base_url.py
@@ -60,10 +60,9 @@ class TestCustomBaseUrlSchema:
         assert "base_url" not in config.kwargs
         assert "api_key_env" not in config.kwargs
 
-    def test_fields_default_to_none(self):
-        config = _make_config()
-        assert config.base_url is None
-        assert config.api_key_env is None
+    def test_openai_config_requires_api_key_env(self):
+        with pytest.raises(ValueError, match="api_key_env is required"):
+            _make_config()
 
 
 class TestCustomBaseUrlClientInit:
@@ -81,10 +80,13 @@ class TestCustomBaseUrlClientInit:
         assert call_args.kwargs["base_url"] == "https://inference.baseten.co/v1"
         assert call_args.kwargs["api_key"] == "baseten-secret"
 
-    def test_defaults_preserve_standard_openai_behavior(self, monkeypatch):
+    def test_standard_openai_key_must_be_explicit(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
         monkeypatch.delenv("BASETEN_API_KEY", raising=False)
-        config = _make_config(provider="openai")  # no base_url / api_key_env
+        config = _make_config(
+            provider="openai",
+            api_key_env="OPENAI_API_KEY",
+        )
 
         call_args = _init_client_with_config(config)
 

--- a/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
+++ b/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
@@ -1,6 +1,11 @@
 """Compatibility tests for the pinned Google Gen AI SDK."""
 
+from unittest.mock import patch
+
 from google.genai import types
+
+from arc_agi_benchmarking.adapters.gemini import GeminiAdapter
+from arc_agi_benchmarking.schemas import ModelConfig, ModelPricing
 
 
 def test_gemini_sdk_supports_thinking_level():
@@ -10,3 +15,22 @@ def test_gemini_sdk_supports_thinking_level():
 
     assert config.thinking_config is not None
     assert config.thinking_config.thinking_level == types.ThinkingLevel.MEDIUM
+
+
+def test_gemini_init_uses_configured_api_key_env(monkeypatch):
+    config = ModelConfig(
+        name="test-gemini",
+        model_name="gemini-test",
+        provider="gemini",
+        api_key_env="CUSTOM_GEMINI_KEY",
+        pricing=ModelPricing(date="2026-07-27", input=1.0, output=2.0),
+    )
+    monkeypatch.setenv("CUSTOM_GEMINI_KEY", "custom-gemini-secret")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    adapter = GeminiAdapter.__new__(GeminiAdapter)
+    adapter.model_config = config
+    with patch("arc_agi_benchmarking.adapters.gemini.genai.Client") as client:
+        adapter.init_client()
+
+    client.assert_called_once_with(api_key="custom-gemini-secret")

--- a/src/arc_agi_benchmarking/tests/test_openai_providers.py
+++ b/src/arc_agi_benchmarking/tests/test_openai_providers.py
@@ -65,6 +65,7 @@ def mock_model_config(adapter_class):
         provider=provider_name, 
         pricing=ModelPricing(date="2024-01-01", input=1.0, output=2.0), 
         api_type=APIType.CHAT_COMPLETIONS, # Assuming chat completions for simplicity
+        api_key_env="OPENAI_API_KEY" if provider_name == "openai" else None,
         kwargs={"temperature": 0.5}
     )
 

--- a/src/arc_agi_benchmarking/tests/test_openai_providers.py
+++ b/src/arc_agi_benchmarking/tests/test_openai_providers.py
@@ -59,13 +59,24 @@ def mock_model_config(adapter_class):
     # Handle potential variations if needed (e.g., fireworks vs fireworks-ai)
     # For now, simple lowercase name works for openai, grok, deepseek, fireworks
 
+    api_key_envs = {
+        "openai": "OPENAI_API_KEY",
+        "grok": "XAI_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "fireworks": "FIREWORKS_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
+        "dashscope": "DASHSCOPE_API_KEY",
+        "mulerouter": "MULEROUTER_API_KEY",
+        "xai": "XAI_API_KEY",
+    }
+
     return ModelConfig(
         name=config_name,
         model_name=model_name,
         provider=provider_name, 
         pricing=ModelPricing(date="2024-01-01", input=1.0, output=2.0), 
         api_type=APIType.CHAT_COMPLETIONS, # Assuming chat completions for simplicity
-        api_key_env="OPENAI_API_KEY" if provider_name == "openai" else None,
+        api_key_env=api_key_envs[provider_name],
         kwargs={"temperature": 0.5}
     )
 

--- a/src/arc_agi_benchmarking/tests/test_preflight.py
+++ b/src/arc_agi_benchmarking/tests/test_preflight.py
@@ -18,7 +18,6 @@ from arc_agi_benchmarking.utils.preflight import (
     ValidationResult,
     CostEstimate,
     PreflightReport,
-    PROVIDER_API_KEYS,
 )
 from arc_agi_benchmarking.schemas import ModelConfig, ModelPricing
 from arc_agi_benchmarking.utils.task_utils import read_models_config, read_provider_rate_limits
@@ -61,10 +60,7 @@ class TestValidateApiKey:
     def test_known_provider_without_key(self):
         """Test that a known provider without an API key fails."""
         with patch.dict(os.environ, {}, clear=True):
-            # Clear any existing DEEPSEEK_API_KEY
-            if "DEEPSEEK_API_KEY" in os.environ:
-                del os.environ["DEEPSEEK_API_KEY"]
-            result = validate_api_key("deepseek")
+            result = validate_api_key("deepseek", "DEEPSEEK_API_KEY")
             assert result.passed is False
             assert "not found" in result.message.lower()
 
@@ -99,41 +95,35 @@ class TestValidateApiKey:
         assert result.passed is True
         assert "no api key required" in result.message.lower()
 
-    def test_unknown_provider(self):
-        """Test that an unknown provider returns failure."""
-        result = validate_api_key("unknown_provider_xyz")
-        assert result.passed is False
-        assert "unknown provider" in result.message.lower()
-
     def test_codex_with_either_key(self):
         """Test that codex accepts either OPENAI_API_KEY or CODEX_API_KEY."""
         # Test with OPENAI_API_KEY
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test12345678"}, clear=True):
-            result = validate_api_key("codex")
+            result = validate_api_key("codex", "OPENAI_API_KEY")
             assert result.passed is True
 
         # Test with CODEX_API_KEY
         with patch.dict(os.environ, {"CODEX_API_KEY": "codex-test12345678"}, clear=True):
-            result = validate_api_key("codex")
+            result = validate_api_key("codex", "CODEX_API_KEY")
             assert result.passed is True
 
     def test_together_provider_with_key(self):
         """Test that Together accepts TOGETHER_API_KEY."""
         with patch.dict(os.environ, {"TOGETHER_API_KEY": "tog-test12345678"}, clear=True):
-            result = validate_api_key("together")
+            result = validate_api_key("together", "TOGETHER_API_KEY")
             assert result.passed is True
             assert "TOGETHER_API_KEY" in result.message
 
     def test_together_provider_without_key(self):
         """Test that Together fails clearly without TOGETHER_API_KEY."""
         with patch.dict(os.environ, {}, clear=True):
-            result = validate_api_key("together")
+            result = validate_api_key("together", "TOGETHER_API_KEY")
             assert result.passed is False
             assert "TOGETHER_API_KEY" in result.details
 
-    def test_together_provider_key_mapping_exists(self):
-        """Test that preflight knows which environment key Together uses."""
-        assert PROVIDER_API_KEYS["together"] == ["TOGETHER_API_KEY"]
+    def test_together_config_names_its_api_key(self):
+        config = read_models_config("deepseek-v4-pro-together")
+        assert config.api_key_env == "TOGETHER_API_KEY"
 
 
 class TestTogetherConfigIntegration:
@@ -257,6 +247,7 @@ class TestEstimateCost:
             name="test-model",
             model_name="test-model",
             provider="test",
+            api_key_env="TEST_API_KEY",
             pricing=ModelPricing(date="2024-01-01", input=1.0, output=2.0)
         )
 
@@ -283,6 +274,7 @@ class TestEstimateCost:
             name="test-model",
             model_name="test-model",
             provider="test",
+            api_key_env="TEST_API_KEY",
             pricing=ModelPricing(date="2024-01-01", input=10.0, output=30.0)
         )
 
@@ -367,20 +359,3 @@ class TestPreflightReport:
         assert "✓" in report_str  # Passed check
         assert "✗" in report_str  # Failed check
         assert "FAILED" in report_str  # Overall status
-
-
-class TestProviderApiKeyMapping:
-    """Tests for PROVIDER_API_KEYS mapping."""
-
-    def test_all_major_providers_covered(self):
-        """Test that all major providers are in the mapping."""
-        expected_providers = [
-            "openai", "anthropic", "gemini", "deepseek",
-            "fireworks", "xai", "groq", "openrouter", "random"
-        ]
-        for provider in expected_providers:
-            assert provider in PROVIDER_API_KEYS, f"Provider {provider} not in PROVIDER_API_KEYS"
-
-    def test_random_provider_has_no_keys(self):
-        """Test that random provider has empty key list."""
-        assert PROVIDER_API_KEYS["random"] == []

--- a/src/arc_agi_benchmarking/tests/test_preflight.py
+++ b/src/arc_agi_benchmarking/tests/test_preflight.py
@@ -60,6 +60,31 @@ class TestValidateApiKey:
             assert result.passed is False
             assert "not found" in result.message.lower()
 
+    def test_config_specific_key_overrides_provider_default(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-openai12345678",
+                "THINKY_API_KEY": "thinky-test12345678",
+            },
+            clear=True,
+        ):
+            result = validate_api_key("openai", "THINKY_API_KEY")
+
+        assert result.passed is True
+        assert "THINKY_API_KEY" in result.message
+
+    def test_missing_config_specific_key_does_not_fall_back(self):
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "sk-openai12345678"},
+            clear=True,
+        ):
+            result = validate_api_key("openai", "THINKY_API_KEY")
+
+        assert result.passed is False
+        assert "THINKY_API_KEY" in result.details
+
     def test_random_provider_no_key_needed(self):
         """Test that the random provider doesn't need an API key."""
         result = validate_api_key("random")

--- a/src/arc_agi_benchmarking/tests/test_preflight.py
+++ b/src/arc_agi_benchmarking/tests/test_preflight.py
@@ -46,9 +46,17 @@ class TestValidateApiKey:
     def test_known_provider_with_key(self):
         """Test that a known provider with an API key passes."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test12345678"}):
-            result = validate_api_key("openai")
+            result = validate_api_key("openai", "OPENAI_API_KEY")
             assert result.passed is True
             assert "OPENAI_API_KEY" in result.message
+
+    def test_openai_provider_requires_configured_key_name(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test12345678"}):
+            result = validate_api_key("openai")
+
+        assert result.passed is False
+        assert "not configured" in result.message
+        assert "api_key_env" in result.details
 
     def test_known_provider_without_key(self):
         """Test that a known provider without an API key fails."""

--- a/src/arc_agi_benchmarking/tests/test_together.py
+++ b/src/arc_agi_benchmarking/tests/test_together.py
@@ -13,6 +13,7 @@ def _model_config() -> ModelConfig:
         name="test-together-model",
         model_name="deepseek-ai/DeepSeek-V4-Pro",
         provider="together",
+        api_key_env="TOGETHER_API_KEY",
         pricing=ModelPricing(date="2026-04-27", input=1.0, output=2.0),
         api_type=APIType.CHAT_COMPLETIONS,
         kwargs={"temperature": 0.0},

--- a/src/arc_agi_benchmarking/utils/preflight.py
+++ b/src/arc_agi_benchmarking/utils/preflight.py
@@ -144,9 +144,15 @@ def validate_api_key(
     provider: str,
     api_key_env: Optional[str] = None,
 ) -> ValidationResult:
-    """Check the config-specific API key, falling back to provider defaults."""
+    """Check the config-specific key or the dedicated provider's fixed key."""
     if api_key_env:
         required_keys = [api_key_env]
+    elif provider == "openai":
+        return ValidationResult(
+            passed=False,
+            message="API key environment variable not configured for 'openai'",
+            details="Set api_key_env in the model config"
+        )
     elif provider not in PROVIDER_API_KEYS:
         return ValidationResult(
             passed=False,

--- a/src/arc_agi_benchmarking/utils/preflight.py
+++ b/src/arc_agi_benchmarking/utils/preflight.py
@@ -140,16 +140,21 @@ def validate_config_exists(config_name: str) -> ValidationResult:
         )
 
 
-def validate_api_key(provider: str) -> ValidationResult:
-    """Check if the required API key exists for the provider."""
-    if provider not in PROVIDER_API_KEYS:
+def validate_api_key(
+    provider: str,
+    api_key_env: Optional[str] = None,
+) -> ValidationResult:
+    """Check the config-specific API key, falling back to provider defaults."""
+    if api_key_env:
+        required_keys = [api_key_env]
+    elif provider not in PROVIDER_API_KEYS:
         return ValidationResult(
             passed=False,
             message=f"Unknown provider '{provider}'",
             details=f"Known providers: {', '.join(PROVIDER_API_KEYS.keys())}"
         )
-
-    required_keys = PROVIDER_API_KEYS[provider]
+    else:
+        required_keys = PROVIDER_API_KEYS[provider]
 
     if not required_keys:
         return ValidationResult(
@@ -345,7 +350,10 @@ def run_preflight(
 
     # 2. Validate API key (only if config was found)
     if model_config:
-        api_result = validate_api_key(model_config.provider)
+        api_result = validate_api_key(
+            model_config.provider,
+            model_config.api_key_env,
+        )
         validations.append(api_result)
     else:
         validations.append(ValidationResult(

--- a/src/arc_agi_benchmarking/utils/preflight.py
+++ b/src/arc_agi_benchmarking/utils/preflight.py
@@ -9,31 +9,13 @@ import os
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 from dataclasses import dataclass
 
 from arc_agi_benchmarking.utils.task_utils import read_models_config
 from arc_agi_benchmarking.schemas import ModelConfig
 
 logger = logging.getLogger(__name__)
-
-# Provider to environment variable mapping
-PROVIDER_API_KEYS: Dict[str, List[str]] = {
-    "openai": ["OPENAI_API_KEY"],
-    "anthropic": ["ANTHROPIC_API_KEY"],
-    "claude_agent_sdk": ["ANTHROPIC_API_KEY"],
-    "gemini": ["GOOGLE_API_KEY"],
-    "google": ["GOOGLE_API_KEY"],
-    "deepseek": ["DEEPSEEK_API_KEY"],
-    "fireworks": ["FIREWORKS_API_KEY"],
-    "xai": ["XAI_API_KEY"],
-    "grok": ["XAI_API_KEY"],
-    "groq": ["GROQ_API_KEY"],
-    "openrouter": ["OPENROUTER_API_KEY"],
-    "together": ["TOGETHER_API_KEY"],
-    "codex": ["OPENAI_API_KEY", "CODEX_API_KEY"],  # Either works
-    "random": [],  # No API key needed
-}
 
 # Average tokens per ARC task (empirically estimated)
 # This is a rough estimate based on typical task sizes
@@ -144,46 +126,33 @@ def validate_api_key(
     provider: str,
     api_key_env: Optional[str] = None,
 ) -> ValidationResult:
-    """Check the config-specific key or the dedicated provider's fixed key."""
-    if api_key_env:
-        required_keys = [api_key_env]
-    elif provider == "openai":
-        return ValidationResult(
-            passed=False,
-            message="API key environment variable not configured for 'openai'",
-            details="Set api_key_env in the model config"
-        )
-    elif provider not in PROVIDER_API_KEYS:
-        return ValidationResult(
-            passed=False,
-            message=f"Unknown provider '{provider}'",
-            details=f"Known providers: {', '.join(PROVIDER_API_KEYS.keys())}"
-        )
-    else:
-        required_keys = PROVIDER_API_KEYS[provider]
-
-    if not required_keys:
+    """Check the API key named by the model configuration."""
+    if provider == "random":
         return ValidationResult(
             passed=True,
-            message=f"No API key required for '{provider}'"
+            message="No API key required for 'random'"
         )
 
-    # Check if any of the valid keys exist
-    for key_name in required_keys:
-        if os.environ.get(key_name):
-            # Mask the key for security
-            key_value = os.environ.get(key_name, "")
-            masked = key_value[:4] + "..." + key_value[-4:] if len(key_value) > 8 else "***"
-            return ValidationResult(
-                passed=True,
-                message=f"API key '{key_name}' found",
-                details=f"Value: {masked}"
-            )
+    if not api_key_env:
+        return ValidationResult(
+            passed=False,
+            message=f"API key environment variable not configured for '{provider}'",
+            details="Set api_key_env in the model config"
+        )
+
+    if os.environ.get(api_key_env):
+        key_value = os.environ.get(api_key_env, "")
+        masked = key_value[:4] + "..." + key_value[-4:] if len(key_value) > 8 else "***"
+        return ValidationResult(
+            passed=True,
+            message=f"API key '{api_key_env}' found",
+            details=f"Value: {masked}"
+        )
 
     return ValidationResult(
         passed=False,
         message=f"API key not found for '{provider}'",
-        details=f"Set one of: {', '.join(required_keys)}"
+        details=f"Set: {api_key_env}"
     )
 
 


### PR DESCRIPTION
## Summary

- Require every model config except `provider: random` to explicitly set `api_key_env`.
- Make every authenticated adapter read the environment variable named by its model config.
- Remove provider-specific API-key defaults and hardcoded credential lookups.
- Update all 138 authenticated checked-in configs with their current key names.
- Make preflight validate and report the exact configured environment variable.
- Document the universal configuration requirement in the README and `.env.example`.

## Problem

API-key selection was split between model configuration, preflight provider mappings, and hardcoded adapter behavior. This caused preflight and runtime to disagree for custom `api_key_env` values, and prevented users from choosing a different environment-variable name for providers such as Anthropic or Gemini.

More critically, an OpenAI-compatible config could use `provider: openai` with a third-party `base_url` while omitting `api_key_env`. The adapter would then default to `OPENAI_API_KEY` and send that credential to the third-party endpoint. Requiring an explicit key name removes that accidental credential-exposure path.

## New configuration contract

Every authenticated model config must name the environment variable containing its API key:

```yaml
provider: anthropic
api_key_env: MY_ANTHROPIC_KEY
```

All adapters resolve credentials through this field. SDK and CLI adapters that require a fixed child-process variable translate the configured value internally. Adapters do not assume or fall back to a provider-default variable.

`provider: random` is the sole exemption because it does not authenticate with an external service.

Private or downstream configs must add `api_key_env` when upgrading.

## Tests

- Full suite: 504 passed, 9 skipped
- Validated all 139 checked-in model configs: 138 explicitly configure `api_key_env`; only `random-baseline` is keyless
- Added coverage showing Anthropic and Gemini accept custom environment-variable names