### PR TITLE
Retry null attempts when resuming benchmarks

### DIFF
--- a/cli/run_all.py
+++ b/cli/run_all.py
@@ -21,7 +21,10 @@ if project_root not in sys.path:
 
 from main import ARCTester
 from arc_agi_benchmarking.utils.task_utils import read_models_config, read_provider_rate_limits, get_provider_timeout_config
-from arc_agi_benchmarking.utils.submission_exists import submission_exists
+from arc_agi_benchmarking.utils.submission_exists import (
+    submission_exists,
+    submission_is_complete,
+)
 from arc_agi_benchmarking.utils.rate_limiter import AsyncRequestRateLimiter
 from arc_agi_benchmarking.utils.concurrency_limiter import ProviderConcurrencyLimiter
 from arc_agi_benchmarking.utils.metrics import set_metrics_enabled, set_metrics_filename_prefix
@@ -112,6 +115,14 @@ PROVIDER_CONCURRENCY_LIMITERS: Dict[str, ProviderConcurrencyLimiter] = {}
 PROVIDER_CIRCUIT_BREAKERS: Dict[str, CircuitBreaker] = {}
 PROVIDER_TIMEOUT_CONFIGS: Dict[str, Dict] = {}
 MODEL_CONFIG_CACHE: Dict[str, Any] = {}
+
+
+def get_task_test_pair_count(data_dir: str, task_id: str) -> int:
+    task_path = os.path.join(data_dir, f"{task_id}.json")
+    with open(task_path, "r") as f:
+        task_data = json.load(f)
+    return len(task_data.get("test", []))
+
 
 def get_model_config(config_name: str):
     if config_name not in MODEL_CONFIG_CACHE:
@@ -451,6 +462,12 @@ async def main(task_list_file: Optional[str],
             task_id
             for task_id in task_ids
             if not submission_exists(save_submission_dir, task_id)
+            or not submission_is_complete(
+                save_submission_dir,
+                task_id,
+                get_task_test_pair_count(data_dir, task_id),
+                num_attempts,
+            )
         ]
         skipped_existing_submissions = len(task_ids) - len(tasks_to_run)
         if skipped_existing_submissions > 0:

--- a/main.py
+++ b/main.py
@@ -189,9 +189,9 @@ class ARCTester:
             self.provider: The initialized provider adapter.
 
         Returns:
-            A list representing the submission structure if successful and saving is enabled,
-            or None if no valid predictions were made or saving is disabled but run completes.
-            Returns None immediately if submission exists and overwrite is False.
+            A list representing the submission structure. Existing non-null attempts are
+            preserved unless overwrite is enabled. Returns None immediately if an existing
+            submission already contains every expected non-null attempt.
         """
 
         logger.info(f"Running task {task_id} with config {self.config}")
@@ -202,22 +202,39 @@ class ARCTester:
 
         logger.info(f"Using model_config: {test_id} for task_id: {task_id}")
 
-        # Logic for overwrite. If save_submission_dir is provided, check if the submission already exists
+        train_pairs = utils.get_train_pairs_from_task(data_dir, task_id)
+        test_input_pairs = utils.get_test_input_from_task(data_dir, task_id)
+        test_pairs = utils.get_test_pairs_from_task(data_dir, task_id)
+
+        task_attempts = [dict() for _ in test_input_pairs]
         if (
             self.save_submission_dir
             and utils.submission_exists(self.save_submission_dir, task_id)
             and not self.overwrite_submission
         ):
-            logger.info(
-                f"Submission for task {task_id} using {test_id} already exists, skipping"
+            saved_submission = utils.load_submission(
+                self.save_submission_dir, task_id
             )
-            return
+            task_attempts = utils.normalize_submission_pairs(
+                saved_submission, len(test_input_pairs)
+            )
+            if utils.submission_attempts_complete(
+                task_attempts, self.num_attempts
+            ):
+                logger.info(
+                    f"Submission for task {task_id} using {test_id} is complete, skipping"
+                )
+                return
 
-        task_attempts = []
-
-        train_pairs = utils.get_train_pairs_from_task(data_dir, task_id)
-        test_input_pairs = utils.get_test_input_from_task(data_dir, task_id)
-        test_pairs = utils.get_test_pairs_from_task(data_dir, task_id)
+            missing_attempt_count = sum(
+                pair_attempts.get(f"attempt_{attempt_num}") is None
+                for pair_attempts in task_attempts
+                for attempt_num in range(1, self.num_attempts + 1)
+            )
+            logger.info(
+                f"Submission for task {task_id} using {test_id} has "
+                f"{missing_attempt_count} null or missing attempt(s); retrying them"
+            )
 
         # Go through each test pair to get a prediction. 96% of challenges have 1 pair.
         for t, pair_input_obj in enumerate(test_input_pairs):
@@ -226,11 +243,17 @@ class ARCTester:
                 f"Starting task {task_id}, ModelConfig: {test_id}, Test Pair Index: {pair_index + 1}/{len(test_input_pairs)}"
             )
 
-            pair_submission_attempts = {}
+            pair_submission_attempts = task_attempts[pair_index]
 
             # Run through each prediction attempt
             for attempt_num in range(1, self.num_attempts + 1):
                 attempt_key = f"attempt_{attempt_num}"
+                if pair_submission_attempts.get(attempt_key) is not None:
+                    logger.debug(
+                        f"    Task {task_id}, ModelConfig {test_id}, Pair {pair_index + 1}, "
+                        f"Attempt #{attempt_num} already has a response; preserving it"
+                    )
+                    continue
                 pair_submission_attempts[attempt_key] = None
 
                 for retry_num in range(self.retry_attempts):
@@ -276,28 +299,26 @@ class ARCTester:
                             f"    Task {task_id}, ModelConfig {test_id}, Pair {pair_index + 1}, All {self.retry_attempts} retries failed for attempt #{attempt_num}"
                         )
 
-            # Only append non-None attempts for this pair
-            if any(v is not None for v in pair_submission_attempts.values()):
-                task_attempts.append(pair_submission_attempts)
-
-        if task_attempts:
-            if self.print_submission:
-                # Log the submission content; use json.dumps for potentially large structures
-                logger.info(
-                    f"Final submission for task {task_id}, ModelConfig {test_id}:\n{json.dumps(task_attempts, indent=4)}"
-                )
-
-            if self.save_submission_dir:
-                utils.save_submission(self.save_submission_dir, task_id, task_attempts)
-                logger.info(
-                    f"Submission for task {task_id}, ModelConfig {test_id} saved to {self.save_submission_dir}"
-                )
-        else:
-            logger.warning(
-                f"No valid predictions for task {task_id}, ModelConfig {test_id} after all attempts. Skipping submission."
+        if self.print_submission:
+            # Log the submission content; use json.dumps for potentially large structures
+            logger.info(
+                f"Final submission for task {task_id}, ModelConfig {test_id}:\n{json.dumps(task_attempts, indent=4)}"
             )
 
-        return task_attempts if task_attempts else None
+        if self.save_submission_dir:
+            # Save null slots too so scoring can count them as zero and a later run
+            # can identify exactly which attempts still need a response.
+            utils.save_submission(self.save_submission_dir, task_id, task_attempts)
+            logger.info(
+                f"Submission for task {task_id}, ModelConfig {test_id} saved to {self.save_submission_dir}"
+            )
+
+        if not utils.submission_attempts_complete(task_attempts, self.num_attempts):
+            logger.warning(
+                f"Task {task_id}, ModelConfig {test_id} still has null attempts after all retries."
+            )
+
+        return task_attempts
 
 
 def main_cli(cli_args: Optional[List[str]] = None):

--- a/src/arc_agi_benchmarking/tests/test_run_configs.py
+++ b/src/arc_agi_benchmarking/tests/test_run_configs.py
@@ -140,6 +140,14 @@ async def test_max_tasks_per_run_limits_sorted_unsubmitted_tasks(tmp_path):
             "submission_exists",
             side_effect=lambda _directory, task_id: task_id == "task-a",
         ),
+        patch.object(
+            run_all,
+            "submission_is_complete",
+            side_effect=lambda _directory, task_id, _pairs, _attempts: (
+                task_id == "task-a"
+            ),
+        ),
+        patch.object(run_all, "get_task_test_pair_count", return_value=1),
         patch.object(run_all, "run_single_test_wrapper", run_wrapper),
     ):
         exit_code = await run_all.main(

--- a/src/arc_agi_benchmarking/tests/test_submission_resume.py
+++ b/src/arc_agi_benchmarking/tests/test_submission_resume.py
@@ -1,0 +1,198 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from cli import run_all
+from main import ARCTester
+from arc_agi_benchmarking.utils.submission_exists import (
+    normalize_submission_pairs,
+    submission_is_complete,
+)
+
+
+TASK = {
+    "train": [{"input": [[1]], "output": [[1]]}],
+    "test": [
+        {"input": [[2]], "output": [[2]]},
+        {"input": [[3]], "output": [[3]]},
+    ],
+}
+
+
+class StubAttempt:
+    def __init__(self, answer, pair_index):
+        self.answer = answer
+        self.pair_index = pair_index
+        self.correct = None
+
+    def model_dump(self, mode=None):
+        return {
+            "answer": self.answer,
+            "correct": self.correct,
+            "metadata": {"pair_index": self.pair_index},
+        }
+
+
+def _write_task_and_submission(tmp_path, submission):
+    data_dir = tmp_path / "data"
+    submission_dir = tmp_path / "submissions"
+    data_dir.mkdir()
+    submission_dir.mkdir()
+    (data_dir / "task.json").write_text(json.dumps(TASK))
+    (submission_dir / "task.json").write_text(json.dumps(submission))
+    return data_dir, submission_dir
+
+
+def _tester(submission_dir, predictions, num_attempts=2):
+    tester = object.__new__(ARCTester)
+    tester.config = "test-config"
+    tester.save_submission_dir = str(submission_dir)
+    tester.overwrite_submission = False
+    tester.print_submission = False
+    tester.num_attempts = num_attempts
+    tester.retry_attempts = 1
+    tester.get_task_prediction = Mock(side_effect=predictions)
+    return tester
+
+
+def test_normalize_uses_metadata_to_restore_an_omitted_pair():
+    saved = [
+        {
+            "attempt_1": {
+                "answer": [[3]],
+                "metadata": {"pair_index": 1},
+            }
+        }
+    ]
+
+    normalized = normalize_submission_pairs(saved, expected_num_pairs=2)
+
+    assert normalized[0] == {}
+    assert normalized[1] == saved[0]
+
+
+def test_submission_with_null_or_missing_attempt_is_incomplete(tmp_path):
+    _, submission_dir = _write_task_and_submission(
+        tmp_path,
+        [
+            {"attempt_1": {"answer": [[2]]}, "attempt_2": None},
+            {"attempt_1": {"answer": [[3]]}, "attempt_2": {"answer": [[3]]}},
+        ],
+    )
+
+    assert not submission_is_complete(
+        str(submission_dir), "task", expected_num_pairs=2, num_attempts=2
+    )
+
+
+def test_rerun_preserves_responses_and_fills_only_missing_slots(tmp_path):
+    previous_attempt = {
+        "answer": [[2]],
+        "correct": True,
+        "metadata": {"pair_index": 0},
+    }
+    data_dir, submission_dir = _write_task_and_submission(
+        tmp_path,
+        [{"attempt_1": previous_attempt, "attempt_2": None}],
+    )
+    tester = _tester(
+        submission_dir,
+        [
+            StubAttempt([[9]], 0),
+            StubAttempt([[3]], 1),
+            StubAttempt([[8]], 1),
+        ],
+    )
+
+    result = tester.generate_task_solution(str(data_dir), "task")
+
+    assert tester.get_task_prediction.call_count == 3
+    assert result[0]["attempt_1"] == previous_attempt
+    assert result[0]["attempt_2"]["answer"] == [[9]]
+    assert result[1]["attempt_1"]["answer"] == [[3]]
+    assert result[1]["attempt_2"]["answer"] == [[8]]
+    assert result[1]["attempt_1"]["correct"] is True
+    assert result[1]["attempt_2"]["correct"] is False
+    assert submission_is_complete(
+        str(submission_dir), "task", expected_num_pairs=2, num_attempts=2
+    )
+
+
+def test_failed_retry_remains_null_and_is_eligible_on_next_run(tmp_path):
+    data_dir, submission_dir = _write_task_and_submission(
+        tmp_path,
+        [
+            {"attempt_1": {"answer": [[2]], "metadata": {"pair_index": 0}}},
+            {"attempt_1": {"answer": [[3]], "metadata": {"pair_index": 1}}},
+        ],
+    )
+    tester = _tester(submission_dir, [None, None])
+
+    tester.generate_task_solution(str(data_dir), "task")
+
+    saved = json.loads((submission_dir / "task.json").read_text())
+    assert saved[0]["attempt_2"] is None
+    assert saved[1]["attempt_2"] is None
+    assert not submission_is_complete(
+        str(submission_dir), "task", expected_num_pairs=2, num_attempts=2
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_all_schedules_only_submission_with_missing_attempts(tmp_path):
+    data_dir = tmp_path / "data"
+    submission_dir = tmp_path / "submissions"
+    data_dir.mkdir()
+    submission_dir.mkdir()
+    for task_id in ("complete", "incomplete"):
+        (data_dir / f"{task_id}.json").write_text(json.dumps(TASK))
+
+    complete_pair = {
+        "attempt_1": {"answer": [[1]]},
+        "attempt_2": {"answer": [[1]]},
+    }
+    (submission_dir / "complete.json").write_text(
+        json.dumps([complete_pair, complete_pair])
+    )
+    (submission_dir / "incomplete.json").write_text(
+        json.dumps(
+            [
+                {"attempt_1": {"answer": [[1]]}, "attempt_2": None},
+                complete_pair,
+            ]
+        )
+    )
+
+    model_config = SimpleNamespace(
+        provider="submission-resume-provider",
+        name="submission-resume-config",
+        kwargs={},
+    )
+    run_wrapper = AsyncMock(return_value=True)
+    with (
+        patch.object(run_all, "get_model_config", return_value=model_config),
+        patch.object(
+            run_all,
+            "read_provider_rate_limits",
+            return_value={
+                "submission-resume-provider": {"rate": 100, "period": 60}
+            },
+        ),
+        patch.object(run_all, "run_single_test_wrapper", run_wrapper),
+    ):
+        exit_code = await run_all.main(
+            task_list_file=None,
+            config_to_test="submission-resume-config",
+            data_dir=str(data_dir),
+            save_submission_dir=str(submission_dir),
+            overwrite_submission=False,
+            print_submission=False,
+            num_attempts=2,
+            retry_attempts=1,
+            logs_base_dir=tmp_path / "logs",
+        )
+
+    assert exit_code == 0
+    assert [call.args[1] for call in run_wrapper.await_args_list] == ["incomplete"]

--- a/src/arc_agi_benchmarking/utils/submission_exists.py
+++ b/src/arc_agi_benchmarking/utils/submission_exists.py
@@ -1,22 +1,98 @@
+import json
 import os
+from typing import Any, Dict, List, Optional
 
-def submission_exists(submission_dir, task_id):
+
+def _submission_file(submission_dir: str, task_id: str) -> str:
+    return os.path.join(os.path.abspath(submission_dir), f"{task_id}.json")
+
+
+def submission_exists(submission_dir: str, task_id: str) -> bool:
+    """Return whether a submission file exists for ``task_id``."""
+    return os.path.exists(_submission_file(submission_dir, task_id))
+
+
+def load_submission(submission_dir: str, task_id: str) -> Optional[List[Any]]:
+    """Load a submission, returning ``None`` when it is absent or malformed."""
+    try:
+        with open(_submission_file(submission_dir, task_id), "r") as f:
+            submission = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+    return submission if isinstance(submission, list) else None
+
+
+def _metadata_pair_index(pair_attempts: Dict[str, Any]) -> Optional[int]:
+    for attempt in pair_attempts.values():
+        if not isinstance(attempt, dict):
+            continue
+        metadata = attempt.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        pair_index = metadata.get("pair_index")
+        if isinstance(pair_index, int) and not isinstance(pair_index, bool):
+            return pair_index
+    return None
+
+
+def normalize_submission_pairs(
+    submission: Optional[List[Any]], expected_num_pairs: int
+) -> List[Dict[str, Any]]:
+    """Map saved pairs to task pair indexes, retaining valid prior attempts.
+
+    Older submissions may omit a test pair when every attempt for that pair was
+    null. Non-null attempts include their pair index in metadata, which lets us
+    put later saved pairs back into their correct positions.
     """
-    Check if a submission already exists
-    
-    Args:
-    submission_dir (str): Directory where submissions are stored (can be relative)
-    task_id (str): ID of the task to check
+    normalized: List[Dict[str, Any]] = [dict() for _ in range(expected_num_pairs)]
+    if submission is None:
+        return normalized
 
-    Returns:
-    bool: True if the submission exists, False otherwise
-    """
-    # Convert submission_dir to absolute path
-    abs_submission_dir = os.path.abspath(submission_dir)
-    
-    # Check if the submission file exists
-    submission_file = os.path.join(abs_submission_dir, f"{task_id}.json")
-    
-    submission_exists = os.path.exists(submission_file)
+    for saved_position, pair_attempts in enumerate(submission):
+        if not isinstance(pair_attempts, dict):
+            continue
 
-    return submission_exists
+        metadata_index = _metadata_pair_index(pair_attempts)
+        candidate_indexes = (metadata_index, saved_position)
+        target_index = next(
+            (
+                index
+                for index in candidate_indexes
+                if index is not None
+                and 0 <= index < expected_num_pairs
+                and not normalized[index]
+            ),
+            None,
+        )
+        if target_index is not None:
+            normalized[target_index] = dict(pair_attempts)
+
+    return normalized
+
+
+def submission_attempts_complete(
+    task_attempts: List[Dict[str, Any]], num_attempts: int
+) -> bool:
+    """Return whether every expected pair has every expected non-null attempt."""
+    return bool(task_attempts) and all(
+        pair_attempts.get(f"attempt_{attempt_num}") is not None
+        for pair_attempts in task_attempts
+        for attempt_num in range(1, num_attempts + 1)
+    )
+
+
+def submission_is_complete(
+    submission_dir: str,
+    task_id: str,
+    expected_num_pairs: int,
+    num_attempts: int,
+) -> bool:
+    """Return whether a saved submission has all expected non-null attempts."""
+    if expected_num_pairs < 1 or num_attempts < 1:
+        return False
+    submission = load_submission(submission_dir, task_id)
+    if submission is None:
+        return False
+    normalized = normalize_submission_pairs(submission, expected_num_pairs)
+    return submission_attempts_complete(normalized, num_attempts)


### PR DESCRIPTION
## Context

This came up during benchmark testing. The generated and scored task counts matched the dataset size, but some submission files still contained null attempt slots from provider timeouts. Those nulls count as incorrect during scoring even though the model never produced a usable response.

The configured attempt count is intended to give the model a fair number of chances on every test pair. Before this change, resume mode considered a task complete as soon as its submission file existed. A task with one valid response and one timeout therefore remained permanently incomplete at the attempt level while looking complete to the orchestrator.

The available workaround was to disable resume and overwrite the whole task. That is risky for multi-attempt or multi-pair tasks because it discards valid prior responses, including potentially correct ones, and the replacement run can score worse.

## Approach

Resume mode now treats a submission as complete only when every configured test pair has every configured attempt populated. When a partial submission is rerun, the runner:

- preserves every existing non-null response
- calls the provider only for null or missing attempt slots
- reconstructs test-pair positions from attempt metadata when an older submission omitted an entirely null pair
- saves remaining null slots after retries are exhausted so they still score as zero and remain eligible on a later invocation

This makes rerunning the same benchmark command safe: complete tasks are skipped, while partial tasks get their missing chances without losing successful work.

## Tests

- 487 passed via `python -m pytest -q`
- coverage includes explicit null attempts, missing attempt keys, omitted test pairs, preservation of prior responses, and `run_all` scheduling only incomplete submissions