### PR TITLE
Pace individual provider API requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,8 @@ Required API keys (set in `.env`):
 - Adapters should handle their own error cases and return clean strings
 - Preflight validation runs automatically before benchmarks (skip with `--skip-preflight`)
 - Submissions are saved as JSON with `attempt_1`, `attempt_2` keys per task
+
+## Pull Requests
+
+- PR descriptions must explain the context and motivation for the change—what problem prompted it and why the chosen approach is appropriate—not only list the implementation changes.
+- If the relevant background cannot be inferred confidently from the issue, branch, or conversation, ask the user for clarification before creating the PR.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Rather than using the sample data in `data/sample/tasks/`, you can use the real 
 
 ## Running models
 For runs beyond the Quickstart:
-- Batch (recommended): `uv run cli/run_all.py` with your task list, model config, data dir, submission dir, attempts/retries, and log level. Uses asyncio, provider rate limiting, and tenacity retries; outputs land in `--save_submission_dir` (e.g., `submissions/<config>/<version>/<eval_type>`). `run_all` handles one model config per invocation; use `run_configs.py` for multiple configs.
+- Batch (recommended): `uv run cli/run_all.py` with your task list, model config, data dir, submission dir, attempts/retries, and log level. Uses asyncio, best-effort outbound API-request pacing, and tenacity retries; outputs land in `--save_submission_dir` (e.g., `submissions/<config>/<version>/<eval_type>`). `run_all` handles one model config per invocation; use `run_configs.py` for multiple configs. Calls visible to the benchmark runner—including model, parsing, retry, and explicit background/batch control calls—consume rate-limit allowance; starting an ARC task does not. Configured rates are operational ballparks, not strict caps: SDK-managed retries, agent SDKs that hide internal model calls, and synchronous work that continues after a task timeout can produce additional provider traffic.
 - Multiple configs: use `uv run cli/run_configs.py`. It starts one `run_all.py` process per config concurrently, gives each process isolated submission/log directories, and prefixes console output with the config name:
   ```bash
   uv run cli/run_configs.py \

--- a/cli/run_all.py
+++ b/cli/run_all.py
@@ -25,7 +25,7 @@ from arc_agi_benchmarking.utils.submission_exists import (
     submission_exists,
     submission_is_complete,
 )
-from arc_agi_benchmarking.utils.rate_limiter import AsyncRequestRateLimiter
+from arc_agi_benchmarking.utils.rate_limiter import RequestRateLimiter
 from arc_agi_benchmarking.utils.concurrency_limiter import ProviderConcurrencyLimiter
 from arc_agi_benchmarking.utils.metrics import set_metrics_enabled, set_metrics_filename_prefix
 from arc_agi_benchmarking.utils.preflight import run_preflight
@@ -110,7 +110,7 @@ DEFAULT_RETRY_ATTEMPTS = 2
 # DEFAULT_PRINT_LOGS = False # This is now controlled by the global log level
 
 # --- Globals for Orchestrator ---
-PROVIDER_RATE_LIMITERS: Dict[str, AsyncRequestRateLimiter] = {}
+PROVIDER_RATE_LIMITERS: Dict[str, RequestRateLimiter] = {}
 PROVIDER_CONCURRENCY_LIMITERS: Dict[str, ProviderConcurrencyLimiter] = {}
 PROVIDER_CIRCUIT_BREAKERS: Dict[str, CircuitBreaker] = {}
 PROVIDER_TIMEOUT_CONFIGS: Dict[str, Dict] = {}
@@ -166,7 +166,7 @@ def get_or_create_rate_limiter(
     all_provider_limits: Dict,
     model_config: Optional[Any] = None,
     rate_limit_divisor: int = 1,
-) -> AsyncRequestRateLimiter:
+) -> RequestRateLimiter:
     """
     Get or create a rate limiter, checking for model-level config first.
     
@@ -206,7 +206,11 @@ def get_or_create_rate_limiter(
                 calculated_rps = config_rate / config_period
                 actual_rate_for_limiter = calculated_rps
                 config_capacity = model_rate_limit.get('capacity')
-                actual_capacity_for_limiter = config_capacity if config_capacity else max(1.0, calculated_rps)
+                actual_capacity_for_limiter = (
+                    max(1.0, config_capacity / rate_limit_divisor)
+                    if config_capacity is not None
+                    else max(1.0, calculated_rps)
+                )
             logger.info(
                 f"Initializing MODEL-SPECIFIC rate limiter for '{model_config.name}': "
                 f"configured={original_config_rate:g} req/{config_period:g}s, "
@@ -238,14 +242,19 @@ def get_or_create_rate_limiter(
             else:
                 calculated_rps = config_rate / config_period
                 actual_rate_for_limiter = calculated_rps
-                actual_capacity_for_limiter = max(1.0, calculated_rps)
+                config_capacity = limits.get('capacity')
+                actual_capacity_for_limiter = (
+                    max(1.0, config_capacity / rate_limit_divisor)
+                    if config_capacity is not None
+                    else max(1.0, calculated_rps)
+                )
             logger.info(
                 f"Initializing rate limiter for provider '{provider_name}': "
                 f"configured={original_config_rate:g} req/{config_period:g}s, "
                 f"divisor={rate_limit_divisor}, adjusted={config_rate:g} req/{config_period:g}s "
                 f"({actual_rate_for_limiter:.2f} req/s), capacity={actual_capacity_for_limiter:.2f}."
             )
-        PROVIDER_RATE_LIMITERS[limiter_key] = AsyncRequestRateLimiter(rate=actual_rate_for_limiter, capacity=actual_capacity_for_limiter)
+        PROVIDER_RATE_LIMITERS[limiter_key] = RequestRateLimiter(rate=actual_rate_for_limiter, capacity=actual_capacity_for_limiter)
     return PROVIDER_RATE_LIMITERS[limiter_key]
 
 
@@ -272,7 +281,7 @@ def get_task_timeout(provider_name: str, all_provider_limits: Dict, max_task_tim
         return max_task_timeout
     return None
 
-async def run_single_test_wrapper(config_name: str, task_id: str, limiter: AsyncRequestRateLimiter,
+async def run_single_test_wrapper(config_name: str, task_id: str, limiter: RequestRateLimiter,
                                   circuit_breaker: CircuitBreaker,
                                   task_timeout_seconds: Optional[float],
                                   data_dir: str, save_submission_dir: str,
@@ -324,7 +333,8 @@ async def run_single_test_wrapper(config_name: str, task_id: str, limiter: Async
             overwrite_submission=overwrite_submission,
             print_submission=print_submission, # This ARCTester arg controls if it logs submission content
             num_attempts=num_attempts,
-            retry_attempts=retry_attempts # ARCTester's internal retries
+            retry_attempts=retry_attempts, # ARCTester's internal retries
+            request_limiter=limiter,
             # print_logs removed from ARCTester instantiation
         )
         logger.debug(f"[Thread-{task_id}-{config_name}] Starting generate_task_solution...")
@@ -364,20 +374,19 @@ async def run_single_test_wrapper(config_name: str, task_id: str, limiter: Async
             )
 
     try:
-        async with limiter:
-            if concurrency_limiter is None:
-                await _execute_task()
-            else:
+        if concurrency_limiter is None:
+            await _execute_task()
+        else:
+            logger.info(
+                f"[Orchestrator] Waiting for global provider concurrency "
+                f"slot for {config_name} / {task_id}"
+            )
+            async with concurrency_limiter.slot():
                 logger.info(
-                    f"[Orchestrator] Waiting for global provider concurrency "
-                    f"slot for {config_name} / {task_id}"
+                    f"[Orchestrator] Global provider concurrency slot acquired "
+                    f"for {config_name} / {task_id}"
                 )
-                async with concurrency_limiter.slot():
-                    logger.info(
-                        f"[Orchestrator] Global provider concurrency slot acquired "
-                        f"for {config_name} / {task_id}"
-                    )
-                    await _execute_task()
+                await _execute_task()
 
         circuit_breaker.record_success()
         logger.info(f"[Orchestrator] Successfully processed: {config_name} / {task_id}")

--- a/main.py
+++ b/main.py
@@ -61,9 +61,11 @@ class ARCTester:
         print_submission: bool,
         num_attempts: int,
         retry_attempts: int,
+        request_limiter=None,
     ):
         self.config = config
         self.model_config = utils.read_models_config(config)
+        self.request_limiter = request_limiter
         self.provider = self.init_provider(self.model_config.provider)
         self.save_submission_dir = save_submission_dir
         self.overwrite_submission = overwrite_submission
@@ -76,7 +78,7 @@ class ARCTester:
             adapter_cls = PROVIDER_ADAPTERS[provider_name]
         except KeyError:
             raise ValueError(f"Unsupported provider: {provider_name}")
-        return adapter_cls(self.config)
+        return adapter_cls(self.config, request_limiter=self.request_limiter)
 
     def predict_task_output(
         self,

--- a/provider_config.yml
+++ b/provider_config.yml
@@ -1,13 +1,13 @@
 # Provider-specific API rate limits
-# Used by the asyncio orchestrator (cli/run_all.py) to configure AsyncRequestRateLimiter.
-# 'rate' is the number of allowed requests per 'period' seconds.
+# Used by the benchmark runners to pace outbound provider API request attempts.
+# 'rate' is the average number of allowed requests per 'period' seconds.
 
 openai:
   rate: 20
   period: 60    # per 60 seconds
 
 anthropic:
-  rate: 20     # 400 requests
+  rate: 50     # 50 requests
   period: 60    # per 60 seconds
 
 # Provider key for Gemini models, should match 'provider' field in models.yml

--- a/src/arc_agi_benchmarking/adapters/anthropic.py
+++ b/src/arc_agi_benchmarking/adapters/anthropic.py
@@ -22,6 +22,7 @@ class AnthropicAdapter(ProviderAdapter):
         """
         client = anthropic.Anthropic(
             api_key=self.get_api_key(),
+            max_retries=0,
         )
 
         return client
@@ -145,14 +146,18 @@ class AnthropicAdapter(ProviderAdapter):
         betas = self.model_config.kwargs.get('betas')
         api_kwargs = {k: v for k, v in self.model_config.kwargs.items() if k != 'betas'}
         if betas:
-            return self.client.beta.messages.create(
+            return self._request(
+                "beta.messages.create",
+                self.client.beta.messages.create,
                 model=self.model_config.model_name,
                 betas=betas,
                 messages=messages,
                 tools=tools,
                 **api_kwargs
             )
-        return self.client.messages.create(
+        return self._request(
+            "messages.create",
+            self.client.messages.create,
             model=self.model_config.model_name,
             messages=messages,
             tools=tools,
@@ -172,21 +177,27 @@ class AnthropicAdapter(ProviderAdapter):
 
         try:
             if betas:
-                with self.client.beta.messages.stream(
+                stream_context = self._request(
+                    "beta.messages.stream",
+                    self.client.beta.messages.stream,
                     model=self.model_config.model_name,
                     betas=betas,
                     messages=messages,
                     tools=tools,
                     **stream_kwargs
-                ) as stream:
+                )
+                with stream_context as stream:
                     final_message = stream.get_final_message()
             else:
-                with self.client.messages.stream(
+                stream_context = self._request(
+                    "messages.stream",
+                    self.client.messages.stream,
                     model=self.model_config.model_name,
                     messages=messages,
                     tools=tools,
                     **stream_kwargs
-                ) as stream:
+                )
+                with stream_context as stream:
                     final_message = stream.get_final_message()
 
             logger.debug(f"Streaming complete for message ID: {final_message.id}")
@@ -244,9 +255,14 @@ class AnthropicAdapter(ProviderAdapter):
         batches_api = self.client.beta.messages.batches if betas else self.client.messages.batches
 
         if betas:
-            batch = batches_api.create(requests=[request], betas=betas)
+            batch = self._request(
+                "messages.batches.create", batches_api.create,
+                requests=[request], betas=betas
+            )
         else:
-            batch = batches_api.create(requests=[request])
+            batch = self._request(
+                "messages.batches.create", batches_api.create, requests=[request]
+            )
 
         batch_id = batch.id
         logger.debug(f"Created Anthropic batch {batch_id} with custom_id={custom_id}")
@@ -256,7 +272,9 @@ class AnthropicAdapter(ProviderAdapter):
             # mode, which also loops until the response leaves queued/in_progress.
             while batch.processing_status != "ended":
                 time.sleep(_BATCH_POLL_INTERVAL_SECONDS)
-                batch = batches_api.retrieve(batch_id)
+                batch = self._request(
+                    "messages.batches.retrieve", batches_api.retrieve, batch_id
+                )
                 logger.debug(
                     f"Anthropic batch {batch_id} status={batch.processing_status} "
                     f"counts={batch.request_counts}"
@@ -264,7 +282,10 @@ class AnthropicAdapter(ProviderAdapter):
 
             # Stream results back; we only submitted one request so we expect one entry.
             matched = None
-            for result in batches_api.results(batch_id):
+            results = self._request(
+                "messages.batches.results", batches_api.results, batch_id
+            )
+            for result in results:
                 if result.custom_id == custom_id:
                     matched = result
                     break
@@ -294,7 +315,9 @@ class AnthropicAdapter(ProviderAdapter):
             # success or failure above. Failures here are logged but do not
             # override the original exception (if any).
             try:
-                batches_api.delete(batch_id)
+                self._request(
+                    "messages.batches.delete", batches_api.delete, batch_id
+                )
                 logger.debug(f"Deleted Anthropic batch {batch_id}")
             except Exception as delete_err:
                 logger.warning(f"Failed to delete Anthropic batch {batch_id}: {delete_err}")

--- a/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
+++ b/src/arc_agi_benchmarking/adapters/claudeagentsdk.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class ClaudeagentsdkAdapter(ProviderAdapter):
+    request_limit_scope = "adapter_invocation"
     # Scratchpad directory for agentic reasoning
     SCRATCHPAD_DIR = "/tmp/arc_agi_scratchpad"
 
@@ -72,7 +73,12 @@ This iterative approach will help you solve the puzzle more accurately.
 
         The prompt is augmented with instructions to use the scratchpad.
         """
-        return asyncio.run(self._make_prediction_async(prompt, task_id, test_id, pair_index))
+        return self._request(
+            "agent.query_session",
+            lambda: asyncio.run(
+                self._make_prediction_async(prompt, task_id, test_id, pair_index)
+            ),
+        )
 
     async def _make_prediction_async(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:
         """

--- a/src/arc_agi_benchmarking/adapters/codexcli.py
+++ b/src/arc_agi_benchmarking/adapters/codexcli.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class CodexcliAdapter(ProviderAdapter):
+    request_limit_scope = "adapter_invocation"
     SCRATCHPAD_ROOT = "/tmp/arc_agi_scratchpad"
     SCRATCHPAD_INSTRUCTIONS = """
 IMPORTANT: You have access to a scratchpad directory at {scratchpad_dir} for your working notes.
@@ -59,7 +60,12 @@ Web search is disabled.
         scratchpad_dir = self._create_scratchpad_dir(task_id, pair_index, start_time)
         augmented_prompt = self.SCRATCHPAD_INSTRUCTIONS.format(scratchpad_dir=scratchpad_dir) + prompt
 
-        run_result = self._run_codex_exec(augmented_prompt, working_directory=scratchpad_dir)
+        run_result = self._request(
+            "codex.exec_session",
+            self._run_codex_exec,
+            augmented_prompt,
+            working_directory=scratchpad_dir,
+        )
 
         end_time = datetime.now(timezone.utc)
 

--- a/src/arc_agi_benchmarking/adapters/dashscope.py
+++ b/src/arc_agi_benchmarking/adapters/dashscope.py
@@ -21,4 +21,4 @@ class DashScopeAdapter(OpenAIBaseAdapter):
             "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         )
 
-        return OpenAI(api_key=self.get_api_key(), base_url=base_url)
+        return OpenAI(api_key=self.get_api_key(), base_url=base_url, max_retries=0)

--- a/src/arc_agi_benchmarking/adapters/deepseek.py
+++ b/src/arc_agi_benchmarking/adapters/deepseek.py
@@ -7,4 +7,4 @@ class DeepseekAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Deepseek."""
-        return OpenAI(api_key=self.get_api_key(), base_url="https://api.deepseek.com")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.deepseek.com", max_retries=0)

--- a/src/arc_agi_benchmarking/adapters/fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/fireworks.py
@@ -11,7 +11,7 @@ class FireworksAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Fireworks."""
-        return OpenAI(api_key=self.get_api_key(), base_url="https://api.fireworks.ai/inference/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.fireworks.ai/inference/v1", max_retries=0)
 
     def _chat_completion(self, messages: List[Dict[str, str]]) -> Any:
         api_kwargs = _filter_api_kwargs(self.model_config.kwargs)
@@ -19,6 +19,8 @@ class FireworksAdapter(OpenAIBaseAdapter):
         logger.debug(
             f"Calling Fireworks API with model: {self.model_config.model_name} and kwargs: {api_kwargs}"
         )
-        return self.client.chat.completions.create(
+        return self._request(
+            "chat.completions.create",
+            self.client.chat.completions.create,
             model=self.model_config.model_name, messages=messages, **api_kwargs
         )

--- a/src/arc_agi_benchmarking/adapters/gemini.py
+++ b/src/arc_agi_benchmarking/adapters/gemini.py
@@ -20,7 +20,12 @@ class GeminiAdapter(ProviderAdapter):
         """Initialize the Gemini client."""
         self.generation_config_dict = self.model_config.kwargs
         
-        client = genai.Client(api_key=self.get_api_key())
+        client = genai.Client(
+            api_key=self.get_api_key(),
+            http_options=types.HttpOptions(
+                retry_options=types.HttpRetryOptions(attempts=1)
+            ),
+        )
         return client
 
     def make_prediction(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:
@@ -161,7 +166,9 @@ class GeminiAdapter(ProviderAdapter):
         config_params = self.generation_config_dict.copy()
 
         try:
-            response = self.client.models.generate_content(
+            response = self._request(
+                "models.generate_content",
+                self.client.models.generate_content,
                 model=self.model_config.model_name,
                 contents=contents_list,
                 config=types.GenerateContentConfig(**config_params)
@@ -203,7 +210,9 @@ class GeminiAdapter(ProviderAdapter):
 
         try:
             # Stream the content - we only care about the final result
-            stream = self.client.models.generate_content_stream(
+            stream = self._request(
+                "models.generate_content_stream",
+                self.client.models.generate_content_stream,
                 model=self.model_config.model_name,
                 contents=contents_list,
                 config=types.GenerateContentConfig(**config_params)
@@ -270,7 +279,9 @@ class GeminiAdapter(ProviderAdapter):
         }
 
         try:
-            response = self.client.models.generate_content(
+            response = self._request(
+                "models.generate_content.extract_json",
+                self.client.models.generate_content,
                 model=self.model_config.model_name,
                 contents=prompt, 
                 config=types.GenerateContentConfig(**extract_config_params) if extract_config_params else None

--- a/src/arc_agi_benchmarking/adapters/grok.py
+++ b/src/arc_agi_benchmarking/adapters/grok.py
@@ -7,4 +7,4 @@ class GrokAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Grok API."""
-        return OpenAI(api_key=self.get_api_key(), base_url="https://api.x.ai/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.x.ai/v1", max_retries=0)

--- a/src/arc_agi_benchmarking/adapters/groq.py
+++ b/src/arc_agi_benchmarking/adapters/groq.py
@@ -7,4 +7,4 @@ class GroqAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for Groq."""
-        return OpenAI(api_key=self.get_api_key(), base_url="https://api.groq.com/openai/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://api.groq.com/openai/v1", max_retries=0)

--- a/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
+++ b/src/arc_agi_benchmarking/adapters/hugging_face_fireworks.py
@@ -102,7 +102,9 @@ class HuggingFaceFireworksAdapter(ProviderAdapter):
         return attempt
 
     def chat_completion(self, messages: str) -> str:
-        return self.client.chat.completions.create(
+        return self._request(
+            "chat.completions.create",
+            self.client.chat.completions.create,
             model=self.model_config.model_name,
             messages=messages,
             **self.model_config.kwargs

--- a/src/arc_agi_benchmarking/adapters/mulerouter.py
+++ b/src/arc_agi_benchmarking/adapters/mulerouter.py
@@ -10,4 +10,5 @@ class MuleRouterAdapter(OpenAIBaseAdapter):
         return OpenAI(
             api_key=self.get_api_key(),
             base_url="https://api.mulerouter.ai/vendors/openai/v1",
+            max_retries=0,
         )

--- a/src/arc_agi_benchmarking/adapters/openai_base.py
+++ b/src/arc_agi_benchmarking/adapters/openai_base.py
@@ -150,7 +150,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
             f"Calling OpenAI API with model: {self.model_config.model_name} and kwargs: {api_kwargs}"
         )
 
-        return self.client.chat.completions.create(
+        return self._request(
+            "chat.completions.create",
+            self.client.chat.completions.create,
             model=self.model_config.model_name, messages=messages, **api_kwargs
         )
 
@@ -168,7 +170,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
 
         try:
             # Create the stream with usage tracking
-            stream = self.client.chat.completions.create(
+            stream = self._request(
+                "chat.completions.create_stream",
+                self.client.chat.completions.create,
                 model=self.model_config.model_name,
                 messages=messages,
                 stream=True,
@@ -250,7 +254,7 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         """
         Delete a response from the OpenAI API
         """
-        self.client.responses.delete(response_id)
+        self._request("responses.delete", self.client.responses.delete, response_id)
 
     def _responses(self, messages: List[Dict[str, str]]) -> Any:
         """
@@ -262,7 +266,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         if "reasoning" in self.model_config.kwargs:
             api_kwargs["reasoning"] = self.model_config.kwargs["reasoning"]
 
-        resp = self.client.responses.create(
+        resp = self._request(
+            "responses.create",
+            self.client.responses.create,
             model=self.model_config.model_name, input=messages, **api_kwargs
         )
 
@@ -273,7 +279,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         ):
             while resp.status in {"queued", "in_progress"}:
                 sleep(10)
-                resp = self.client.responses.retrieve(resp.id)
+                resp = self._request(
+                    "responses.retrieve", self.client.responses.retrieve, resp.id
+                )
 
             # Delete the background response after we're done with it
             try:
@@ -301,7 +309,9 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
 
         try:
             # Create the stream
-            stream = self.client.responses.create(
+            stream = self._request(
+                "responses.create_stream",
+                self.client.responses.create,
                 model=self.model_config.model_name,
                 input=messages,
                 stream=True,

--- a/src/arc_agi_benchmarking/adapters/openrouter.py
+++ b/src/arc_agi_benchmarking/adapters/openrouter.py
@@ -7,4 +7,4 @@ class OpenRouterAdapter(OpenAIBaseAdapter):
 
     def init_client(self):
         """Initialize the OpenAI client configured for OpenRouter API."""
-        return OpenAI(api_key=self.get_api_key(), base_url="https://openrouter.ai/api/v1")
+        return OpenAI(api_key=self.get_api_key(), base_url="https://openrouter.ai/api/v1", max_retries=0)

--- a/src/arc_agi_benchmarking/adapters/provider.py
+++ b/src/arc_agi_benchmarking/adapters/provider.py
@@ -2,12 +2,24 @@ import abc
 import os
 from typing import List, Dict, Tuple, Any, Optional
 import json
+import logging
 from datetime import datetime
+from typing import Callable, TypeVar
 from arc_agi_benchmarking.schemas import Attempt, ModelConfig
 from arc_agi_benchmarking.utils.task_utils import read_models_config
+from arc_agi_benchmarking.utils.rate_limiter import RequestRateLimiter
+
+logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 class ProviderAdapter(abc.ABC):
-    def __init__(self, config: str):
+    request_limit_scope = "api_request"
+
+    def __init__(
+        self,
+        config: str,
+        request_limiter: Optional[RequestRateLimiter] = None,
+    ):
         """
         Initialize the provider adapter with model configuration.
         
@@ -16,6 +28,7 @@ class ProviderAdapter(abc.ABC):
         """
         self.config = config
         self.model_config: ModelConfig = read_models_config(config)
+        self.request_limiter = request_limiter
         
         # Verify the provider matches the adapter
         adapter_provider = self.__class__.__name__.lower().replace('adapter', '')
@@ -24,6 +37,27 @@ class ProviderAdapter(abc.ABC):
         
         # Initialize the client
         self.client = self.init_client()
+
+        if request_limiter is not None and self.request_limit_scope != "api_request":
+            logger.warning(
+                "%s hides its internal HTTP traffic; rate limiting applies to each "
+                "adapter invocation, not every underlying API request.",
+                self.__class__.__name__,
+            )
+
+    def _request(self, operation: str, call: Callable[..., T], *args, **kwargs) -> T:
+        """Acquire allowance immediately before invoking an outbound SDK call."""
+        request_limiter = getattr(self, "request_limiter", None)
+        if request_limiter is not None:
+            waited = request_limiter.acquire()
+            if waited > 0:
+                logger.info(
+                    "Rate limiter waited %.2fs for %s request (%s)",
+                    waited,
+                    self.model_config.provider,
+                    operation,
+                )
+        return call(*args, **kwargs)
 
     def get_api_key(self) -> str:
         """Read the API key named by this model configuration."""

--- a/src/arc_agi_benchmarking/adapters/together.py
+++ b/src/arc_agi_benchmarking/adapters/together.py
@@ -34,7 +34,7 @@ class TogetherAdapter(ProviderAdapter):
     """Adapter boundary for the official Together SDK."""
 
     def init_client(self):
-        return Together(api_key=self.get_api_key())
+        return Together(api_key=self.get_api_key(), max_retries=0)
 
     def _call_together_model(self, prompt: str) -> Any:
         api_kwargs = _filter_api_kwargs(self.model_config.kwargs)
@@ -42,7 +42,9 @@ class TogetherAdapter(ProviderAdapter):
             raise ValueError("TogetherAdapter streaming is not supported yet")
 
         messages = [{"role": "user", "content": prompt}]
-        return self.client.chat.completions.create(
+        return self._request(
+            "chat.completions.create",
+            self.client.chat.completions.create,
             model=self.model_config.model_name,
             messages=messages,
             **api_kwargs,

--- a/src/arc_agi_benchmarking/adapters/xai.py
+++ b/src/arc_agi_benchmarking/adapters/xai.py
@@ -11,5 +11,6 @@ class XAIAdapter(OpenAIBaseAdapter):
         return OpenAI(
             api_key=self.get_api_key(),
             base_url="https://api.x.ai/v1",
-            timeout=httpx.Timeout(3600, connect=30)
+            timeout=httpx.Timeout(3600, connect=30),
+            max_retries=0,
         )

--- a/src/arc_agi_benchmarking/tests/test_anthropic.py
+++ b/src/arc_agi_benchmarking/tests/test_anthropic.py
@@ -32,7 +32,10 @@ def test_init_client_uses_configured_api_key_env(mock_model_config, monkeypatch)
     with patch("arc_agi_benchmarking.adapters.anthropic.anthropic.Anthropic") as client:
         adapter.init_client()
 
-    client.assert_called_once_with(api_key="custom-anthropic-secret")
+    client.assert_called_once_with(
+        api_key="custom-anthropic-secret",
+        max_retries=0,
+    )
 
 
 @pytest.fixture
@@ -222,6 +225,8 @@ class TestAnthropicBatch:
           4. delete the batch afterwards.
         """
         adapter_instance.model_config.kwargs = {'batch': True, 'max_tokens': 8192}
+        adapter_instance.request_limiter = MagicMock()
+        adapter_instance.request_limiter.acquire.return_value = 0
 
         batches = _make_batch_handle(
             batch_id="msgbatch_abc",
@@ -253,6 +258,7 @@ class TestAnthropicBatch:
 
         # Returned message is the underlying Anthropic message object
         assert result is mock_anthropic_response
+        assert adapter_instance.request_limiter.acquire.call_count == 5
 
         # create called exactly once, with one Request, no betas kwarg
         batches.create.assert_called_once()

--- a/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
+++ b/src/arc_agi_benchmarking/tests/test_gemini_sdk.py
@@ -64,4 +64,7 @@ def test_gemini_init_uses_configured_api_key_env(monkeypatch):
     with patch("arc_agi_benchmarking.adapters.gemini.genai.Client") as client:
         adapter.init_client()
 
-    client.assert_called_once_with(api_key="custom-gemini-secret")
+    client.assert_called_once()
+    call_kwargs = client.call_args.kwargs
+    assert call_kwargs["api_key"] == "custom-gemini-secret"
+    assert call_kwargs["http_options"].retry_options.attempts == 1

--- a/src/arc_agi_benchmarking/tests/test_logging.py
+++ b/src/arc_agi_benchmarking/tests/test_logging.py
@@ -14,7 +14,7 @@ if project_root not in sys.path:
 
 # Imports now possible after path adjustment
 from main import ARCTester
-from cli.run_all import main, run_single_test_wrapper, AsyncRequestRateLimiter, get_or_create_rate_limiter
+from cli.run_all import main, run_single_test_wrapper, RequestRateLimiter, get_or_create_rate_limiter
 from arc_agi_benchmarking.schemas import Attempt # Import Attempt schema
 
 # --- Test ARCTester Logging (main.py) ---

--- a/src/arc_agi_benchmarking/tests/test_rate_limiter.py
+++ b/src/arc_agi_benchmarking/tests/test_rate_limiter.py
@@ -1,215 +1,84 @@
-import asyncio
-import time
+import threading
+
 import pytest
-import math
-from arc_agi_benchmarking.utils.rate_limiter import AsyncRequestRateLimiter
 
-# Pytest marker for async tests
-pytestmark = pytest.mark.asyncio
+from arc_agi_benchmarking.utils.rate_limiter import RequestRateLimiter
 
-# Helper for Decimal comparison, mostly useful if precision context changes
-# For default precision, direct == is fine with Decimal("str") inputs.
-# def assert_decimal_equal(a, b):
-#     assert a == b, f"{a} != {b}"
 
-# --- Test Cases ---
+class FakeTime:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps = []
 
-async def test_limiter_initialization():
-    """Test valid and invalid initializations."""
-    # Valid
-    limiter = AsyncRequestRateLimiter(rate=10, capacity=20)
-    assert limiter._rate == 10.0 # Check float
-    assert limiter._capacity == 20.0 # Check float
-    assert limiter._available_requests == 20.0 # Check float
+    def monotonic(self):
+        return self.now
 
-    # Invalid rate
-    with pytest.raises(ValueError, match="Rate must be a positive number"):
-        AsyncRequestRateLimiter(rate=0, capacity=10)
-    with pytest.raises(ValueError, match="Rate must be a positive number"):
-        AsyncRequestRateLimiter(rate=-1, capacity=10)
-        
-    # Invalid capacity
-    with pytest.raises(ValueError, match="Capacity must be a non-negative number"):
-        AsyncRequestRateLimiter(rate=1, capacity=-1)
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.now += seconds
 
-async def test_basic_acquire():
-    """Test acquiring requests when available."""
-    limiter = AsyncRequestRateLimiter(rate=10, capacity=10)
-    start_requests = await limiter.get_available_requests()
-    assert abs(start_requests - 10.0) < 1e-9 # Check close to 10 initially
-    
-    await limiter.acquire(1)
-    actual_9 = await limiter.get_available_requests()
-    # Check value is within a small range around 9.0
-    assert 9.0 - 1e-3 < actual_9 < 9.0 + 1e-3 # Increased tolerance
-    
-    await limiter.acquire(5)
-    actual_4 = await limiter.get_available_requests()
-    # Check value is within a small range around 4.0
-    assert 4.0 - 1e-3 < actual_4 < 4.0 + 1e-3 # Increased tolerance
 
-async def test_consume_capacity():
-    """Test acquiring exactly the capacity quickly."""
-    capacity = 5
-    limiter = AsyncRequestRateLimiter(rate=1, capacity=capacity)
-    
-    start_time = time.monotonic()
-    await limiter.acquire(capacity)
-    end_time = time.monotonic()
-    
-    # Check value is very small (close to zero)
-    assert await limiter.get_available_requests() < 1e-4 
-    assert end_time - start_time < 0.1 
+def make_limiter(rate=10, capacity=1):
+    fake_time = FakeTime()
+    limiter = RequestRateLimiter(
+        rate=rate,
+        capacity=capacity,
+        clock=fake_time.monotonic,
+        sleeper=fake_time.sleep,
+    )
+    return limiter, fake_time
 
-async def test_rate_limit_wait():
-    """Test that acquiring beyond capacity forces a wait based on rate."""
-    rate = 5.0
-    capacity = 3.0
-    limiter = AsyncRequestRateLimiter(rate=rate, capacity=capacity)
 
-    await limiter.acquire(int(capacity))
-    # Check value is very small (close to zero)
-    assert await limiter.get_available_requests() < 1e-4 
-    
-    start_time = time.monotonic()
-    await limiter.acquire(1)
-    end_time = time.monotonic()
-    
-    expected_wait = 1.0 / rate
-    actual_wait = end_time - start_time
-    
-    # Time comparison still uses isclose
-    assert math.isclose(actual_wait, expected_wait, abs_tol=0.05)
-    
-    # After waiting, the available amount might be slightly > 0
-    # Check it's very small again
-    assert await limiter.get_available_requests() < 0.1 # Keep existing check
-    
-async def test_burst_then_rate():
-    """Test the burst capacity followed by rate-limited acquisition."""
-    rate = 2.0
-    capacity = 5.0
-    limiter = AsyncRequestRateLimiter(rate=rate, capacity=capacity)
+def test_limiter_initialization_and_validation():
+    limiter, _ = make_limiter(rate=10, capacity=20)
+    assert limiter._rate == 10.0
+    assert limiter._capacity == 20.0
 
-    start_burst_time = time.monotonic()
-    await limiter.acquire(int(capacity))
-    end_burst_time = time.monotonic()
-    assert end_burst_time - start_burst_time < 0.1
-    # Check value is very small (close to zero)
-    assert await limiter.get_available_requests() < 1e-4 
+    with pytest.raises(ValueError, match="positive"):
+        RequestRateLimiter(rate=0, capacity=1)
+    with pytest.raises(ValueError, match="at least 1"):
+        RequestRateLimiter(rate=1, capacity=0)
 
-    start_wait_time = time.monotonic()
-    await limiter.acquire(1)
-    end_wait_time = time.monotonic()
-    
-    expected_wait = 1.0 / rate
-    actual_wait = end_wait_time - start_wait_time
-    # Time comparison still uses isclose
-    assert math.isclose(actual_wait, expected_wait, abs_tol=0.05)
-    
-    # Check remaining is small
-    assert await limiter.get_available_requests() < 0.1
 
-async def test_refill():
-    """Test that requests refill over time."""
-    rate = 10.0
-    capacity = 5.0
-    limiter = AsyncRequestRateLimiter(rate=rate, capacity=capacity)
+def test_acquire_consumes_allowance_and_waits_for_refill():
+    limiter, fake_time = make_limiter(rate=5, capacity=1)
 
-    await limiter.acquire(int(capacity)) 
-    # Check value is very small (close to zero)
-    # assert await limiter.get_available_requests() < 1e-4 
-    assert await limiter.get_available_requests() < 1e-3 # Increased tolerance
+    assert limiter.acquire() == 0
+    waited = limiter.acquire()
 
-    wait_time = 3.0 / rate
-    await asyncio.sleep(wait_time + 0.01) 
+    assert waited == pytest.approx(0.2)
+    assert fake_time.sleeps == [pytest.approx(0.2)]
+    assert limiter.get_available_requests() == pytest.approx(0)
 
-    available = await limiter.get_available_requests()
-    # Check available is at least close to 3
-    assert available >= 3.0 - 1e-5 
-    assert available <= capacity
 
-    await limiter.acquire(3)
-    remainder = await limiter.get_available_requests()
-    # Check remainder is small (no rounding needed for < check)
-    assert remainder < 0.2 
-    assert remainder >= 0.0
+def test_limiter_supports_configured_burst_capacity():
+    limiter, fake_time = make_limiter(rate=2, capacity=3)
 
-async def test_concurrent_acquires():
-    """Simulate multiple concurrent tasks acquiring requests."""
-    rate = 5.0 
-    capacity = 10.0
-    num_tasks = 15
-    limiter = AsyncRequestRateLimiter(rate=rate, capacity=capacity)
-    results = []
+    assert limiter.acquire(3) == 0
+    assert limiter.acquire() == pytest.approx(0.5)
+    assert fake_time.sleeps == [pytest.approx(0.5)]
 
-    async def worker(worker_id):
-        start_time = time.monotonic()
-        async with limiter:
-            acquire_time = time.monotonic()
-            await asyncio.sleep(0.01)
-            end_time = time.monotonic()
-            results.append({
-                "id": worker_id,
-                "start": start_time,
-                "acquired": acquire_time,
-                "end": end_time
-            })
 
-    overall_start_time = time.monotonic()
-    tasks = [asyncio.create_task(worker(i)) for i in range(num_tasks)]
-    await asyncio.gather(*tasks)
-    overall_end_time = time.monotonic()
-
-    total_duration = overall_end_time - overall_start_time
-    
-    expected_rate_limited_tasks = num_tasks - capacity
-    expected_duration = (expected_rate_limited_tasks / rate) if expected_rate_limited_tasks > 0 else 0
-
-    # Time comparison still uses isclose
-    assert math.isclose(total_duration, expected_duration, rel_tol=0.15, abs_tol=0.05) # More tolerance here
-
-async def test_context_manager():
-    """Test using the limiter as an async context manager."""
-    limiter = AsyncRequestRateLimiter(rate=10, capacity=5)
-    start_req = await limiter.get_available_requests()
-    assert abs(start_req - 5.0) < 1e-9 # Check close to 5 initially
-    async with limiter:
-        actual_4 = await limiter.get_available_requests()
-        # Check value is within a small range around 4.0
-        assert 4.0 - 1e-3 < actual_4 < 4.0 + 1e-3 # Increased tolerance
-    final_req = await limiter.get_available_requests()
-    # Check value is within a small range around 4.0
-    assert 4.0 - 1e-3 < final_req < 4.0 + 1e-3 # Increased tolerance
-
-async def test_acquire_more_than_capacity_error():
-    """Test ValueError when trying to acquire more than capacity."""
-    limiter = AsyncRequestRateLimiter(rate=1, capacity=5)
+def test_invalid_acquisition_is_rejected():
+    limiter, _ = make_limiter(capacity=2)
+    with pytest.raises(ValueError, match="positive integer"):
+        limiter.acquire(0)
     with pytest.raises(ValueError, match="exceeds bucket capacity"):
-        await limiter.acquire(6)
+        limiter.acquire(3)
 
-async def test_acquire_zero_or_negative_error():
-    """Test ValueError when trying to acquire 0 or negative requests."""
-    limiter = AsyncRequestRateLimiter(rate=1, capacity=5)
-    with pytest.raises(ValueError, match="must be a positive integer"):
-        await limiter.acquire(0)
-    with pytest.raises(ValueError, match="must be a positive integer"):
-        await limiter.acquire(-1)
 
-async def test_get_available_requests_basic():
-    """Basic test for the inspection method."""
-    limiter = AsyncRequestRateLimiter(rate=10, capacity=15)
-    assert isinstance(await limiter.get_available_requests(), float) 
-    assert abs(await limiter.get_available_requests() - 15.0) < 1e-9 # Check close to 15
-    await limiter.acquire(3)
-    actual_12 = await limiter.get_available_requests()
-    # Check value is within a small range around 12.0
-    assert 12.0 - 1e-3 < actual_12 < 12.0 + 1e-3 # Increased tolerance
+def test_acquire_is_thread_safe():
+    limiter = RequestRateLimiter(rate=10_000, capacity=1)
+    acquired = []
 
-    await asyncio.sleep(0.1) 
-    # Check close to 13 (existing isclose is fine here)
-    assert math.isclose(await limiter.get_available_requests(), 13.0, abs_tol=0.1)
+    def worker():
+        limiter.acquire()
+        acquired.append(True)
 
-# Note: Testing the sync-call path of get_available_requests is complex
-#       as it involves potentially blocking calls to asyncio.run().
-#       Focusing on the async usage is usually sufficient for library tests. 
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    assert acquired == [True] * 5

--- a/src/arc_agi_benchmarking/tests/test_request_rate_limiting.py
+++ b/src/arc_agi_benchmarking/tests/test_request_rate_limiting.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from main import ARCTester
+from arc_agi_benchmarking.adapters.open_ai import OpenAIAdapter
+from arc_agi_benchmarking.adapters.random import RandomAdapter
+
+
+def test_provider_request_acquires_before_calling_sdk():
+    adapter = RandomAdapter.__new__(RandomAdapter)
+    adapter.model_config = SimpleNamespace(provider="test-provider")
+    events = []
+    adapter.request_limiter = MagicMock(
+        acquire=MagicMock(side_effect=lambda: events.append("acquire") or 0)
+    )
+
+    result = adapter._request(
+        "test.create", lambda: events.append("request") or "response"
+    )
+
+    assert result == "response"
+    assert events == ["acquire", "request"]
+
+
+def test_openai_request_boundary_consumes_one_allowance():
+    adapter = OpenAIAdapter.__new__(OpenAIAdapter)
+    adapter.model_config = SimpleNamespace(
+        provider="openai",
+        model_name="test-model",
+        kwargs={},
+    )
+    adapter.request_limiter = MagicMock()
+    adapter.request_limiter.acquire.return_value = 0
+    adapter.client = MagicMock()
+    adapter.client.chat.completions.create.return_value = "response"
+
+    assert adapter._chat_completion([{"role": "user", "content": "hello"}]) == "response"
+    adapter.request_limiter.acquire.assert_called_once_with()
+    adapter.client.chat.completions.create.assert_called_once()
+
+
+def test_openai_background_control_requests_each_consume_allowance():
+    adapter = OpenAIAdapter.__new__(OpenAIAdapter)
+    adapter.model_config = SimpleNamespace(
+        provider="openai",
+        model_name="test-model",
+        kwargs={"background": True},
+    )
+    adapter.request_limiter = MagicMock()
+    adapter.request_limiter.acquire.return_value = 0
+    adapter.client = MagicMock()
+    queued = SimpleNamespace(id="response-id", status="queued")
+    completed = SimpleNamespace(id="response-id", status="completed")
+    adapter.client.responses.create.return_value = queued
+    adapter.client.responses.retrieve.return_value = completed
+
+    with patch("arc_agi_benchmarking.adapters.openai_base.sleep"):
+        assert adapter._responses([{"role": "user", "content": "hello"}]) is completed
+
+    assert adapter.request_limiter.acquire.call_count == 3
+    adapter.client.responses.create.assert_called_once()
+    adapter.client.responses.retrieve.assert_called_once_with("response-id")
+    adapter.client.responses.delete.assert_called_once_with("response-id")
+
+
+def test_arc_tester_passes_shared_limiter_to_adapter():
+    limiter = MagicMock()
+    model_config = SimpleNamespace(provider="test-provider")
+    captured = {}
+
+    class FakeAdapter:
+        def __init__(self, config, request_limiter=None):
+            captured["config"] = config
+            captured["request_limiter"] = request_limiter
+
+    with (
+        patch("main.utils.read_models_config", return_value=model_config),
+        patch.dict("main.PROVIDER_ADAPTERS", {"test-provider": FakeAdapter}),
+    ):
+        ARCTester(
+            config="test-config",
+            save_submission_dir="submissions",
+            overwrite_submission=False,
+            print_submission=False,
+            num_attempts=1,
+            retry_attempts=1,
+            request_limiter=limiter,
+        )
+
+    assert captured == {
+        "config": "test-config",
+        "request_limiter": limiter,
+    }

--- a/src/arc_agi_benchmarking/tests/test_run_all_retries.py
+++ b/src/arc_agi_benchmarking/tests/test_run_all_retries.py
@@ -7,10 +7,10 @@ from unittest.mock import patch, MagicMock
 # Assuming 'cli.run_all' can be imported. This might require PYTHONPATH adjustments
 # if 'src' isn't the root or if tests are run from a different context.
 # If 'src' is the project root for modules:
-# from cli.run_all import run_single_test_wrapper, AsyncRequestRateLimiter
+# from cli.run_all import run_single_test_wrapper, RequestRateLimiter
 # If 'src' is part of the import path (e.g. 'from src.cli.run_all ...'), adjust as needed.
 # For now, sticking to the simpler form based on common pytest setups from project root.
-from cli.run_all import run_single_test_wrapper, AsyncRequestRateLimiter
+from cli.run_all import run_single_test_wrapper, RequestRateLimiter
 from arc_agi_benchmarking.resilience import CircuitBreaker
 
 # This class was unused and causing a PytestCollectionWarning. Removing it.
@@ -71,7 +71,7 @@ async def test_retry_and_eventual_success(caplog): # Only pytest fixtures like c
             )
             mock_arc_instance.generate_task_solution.side_effect = simulator.simulate_generate_task_solution
 
-            limiter = AsyncRequestRateLimiter(rate=1000, capacity=1000)
+            limiter = MagicMock()
             circuit_breaker = CircuitBreaker("test_provider", failure_threshold=10)
 
             # Execute the function under test
@@ -108,6 +108,9 @@ async def test_retry_and_eventual_success(caplog): # Only pytest fixtures like c
             # Assert the ARCTester class was instantiated for each attempt (initial + retries)
             assert MockARCTesterClass.call_count == expected_calls, \
                 f"Expected ARCTester class to be instantiated {expected_calls} times, but was {MockARCTesterClass.call_count}"
+            limiter_arg = MockARCTesterClass.call_args.kwargs["request_limiter"]
+            assert limiter_arg is limiter
+            limiter.acquire.assert_not_called()
 
     # Optional: Print logs for debugging if the test fails
     # print("\nCaptured Logs for test_retry_and_eventual_success:")
@@ -151,7 +154,7 @@ async def test_failure_after_all_retries(caplog):
             )
             mock_arc_instance.generate_task_solution.side_effect = simulator.simulate_generate_task_solution
 
-            limiter = AsyncRequestRateLimiter(rate=1000, capacity=1000)
+            limiter = RequestRateLimiter(rate=1000, capacity=1000)
             circuit_breaker = CircuitBreaker("test_provider", failure_threshold=10)
 
             result = await run_single_test_wrapper(
@@ -206,7 +209,7 @@ async def test_non_retryable_exception(caplog):
             )
             mock_arc_instance.generate_task_solution.side_effect = simulator.simulate_generate_task_solution
 
-            limiter = AsyncRequestRateLimiter(rate=1000, capacity=1000)
+            limiter = RequestRateLimiter(rate=1000, capacity=1000)
             circuit_breaker = CircuitBreaker("test_provider", failure_threshold=10)
 
             result = await run_single_test_wrapper(
@@ -251,7 +254,7 @@ async def test_missing_submission_is_failure(tmp_path):
         result = await run_single_test_wrapper(
             "test_config_missing_submission",
             "test_task_004",
-            AsyncRequestRateLimiter(rate=1000, capacity=1000),
+            RequestRateLimiter(rate=1000, capacity=1000),
             circuit_breaker=CircuitBreaker(
                 "test_provider", failure_threshold=10
             ),

--- a/src/arc_agi_benchmarking/tests/test_together.py
+++ b/src/arc_agi_benchmarking/tests/test_together.py
@@ -135,7 +135,7 @@ def test_together_adapter_initializes_with_api_key(monkeypatch):
     ) as mock_together:
         adapter = TogetherAdapter("test-together-model")
 
-    mock_together.assert_called_once_with(api_key="test-key")
+    mock_together.assert_called_once_with(api_key="test-key", max_retries=0)
     assert adapter.client is mock_client
     assert adapter.model_config.provider == "together"
 

--- a/src/arc_agi_benchmarking/utils/rate_limiter.py
+++ b/src/arc_agi_benchmarking/utils/rate_limiter.py
@@ -1,105 +1,78 @@
-import asyncio
+"""Thread-safe request rate limiting for synchronous provider SDK calls."""
+
+from __future__ import annotations
+
+import threading
 import time
+from typing import Callable
 
-class AsyncRequestRateLimiter:
-    """
-    An asynchronous request-based rate limiter using the token bucket algorithm.
-    Uses standard floats for rate and request count tracking.
-    """
-    def __init__(self, rate: float, capacity: float):
-        """
-        Initializes the limiter.
 
-        Args:
-            rate: Allowed requests per second (e.g., 5 for 5 RPS).
-            capacity: Maximum pending requests allowed (burst capacity).
-        """
+class RequestRateLimiter:
+    """A token bucket consumed immediately before an outbound API request.
+
+    Provider adapters run in executor threads, so this limiter deliberately uses
+    a regular threading lock and blocking sleep instead of asyncio primitives.
+    """
+
+    def __init__(
+        self,
+        rate: float,
+        capacity: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
         if not isinstance(rate, (int, float)) or not rate > 0:
             raise ValueError("Rate must be a positive number")
-        if not isinstance(capacity, (int, float)) or not capacity >= 0:
-            raise ValueError("Capacity must be a non-negative number")
-            
-        # Use float type directly
-        self._rate = float(rate) 
-        self._capacity = float(capacity)
-        self._available_requests = self._capacity # Start full (float)
-        
-        self._last_refill_time = time.monotonic() # float
-        self._lock = asyncio.Lock()
+        if not isinstance(capacity, (int, float)) or capacity < 1:
+            raise ValueError("Capacity must be at least 1")
 
-    def _refill(self):
-        """Calculates and adds allowed requests based on elapsed time.
-        
-        MUST be called when self._lock is acquired.
-        Uses float for calculations.
-        """
-        now = time.monotonic()
-        elapsed = now - self._last_refill_time # elapsed is float
+        self._rate = float(rate)
+        self._capacity = float(capacity)
+        self._available_requests = self._capacity
+        self._clock = clock
+        self._sleeper = sleeper
+        self._last_refill_time = self._clock()
+        self._lock = threading.Lock()
+
+    def _refill(self) -> None:
+        """Refill the bucket. The caller must hold ``self._lock``."""
+        now = self._clock()
+        elapsed = now - self._last_refill_time
         if elapsed > 0:
-            # Direct float calculation
-            new_requests_allowance = elapsed * self._rate
-            self._available_requests = min(self._capacity, self._available_requests + new_requests_allowance)
+            self._available_requests = min(
+                self._capacity,
+                self._available_requests + elapsed * self._rate,
+            )
             self._last_refill_time = now
 
-    async def acquire(self, requests_needed: int = 1) -> None:
-        """
-        Acquires the specified number of requests, waiting if necessary.
+    def acquire(self, requests_needed: int = 1) -> float:
+        """Consume request allowance, blocking as needed.
 
-        Args:
-            requests_needed: The number of requests required for the operation.
-                           Defaults to 1.
-
-        Raises:
-            ValueError: If requests_needed is not positive or exceeds capacity.
+        Returns the total number of seconds spent waiting.
         """
         if not isinstance(requests_needed, int) or requests_needed <= 0:
             raise ValueError("requests_needed must be a positive integer")
-            
-        # Compare int requests_needed directly with float capacity
         if requests_needed > self._capacity:
             raise ValueError(
                 f"Requested requests ({requests_needed}) exceeds bucket capacity "
                 f"({self._capacity}) - acquisition impossible."
             )
 
+        waited = 0.0
         while True:
-            async with self._lock:
+            with self._lock:
                 self._refill()
-                
-                # Compare float >= int
                 if self._available_requests >= requests_needed:
                     self._available_requests -= requests_needed
-                    return
-                
-                # Calculate wait time using float
-                needed = requests_needed - self._available_requests
-                # Basic check to avoid division by zero if rate is zero (shouldn't happen)
-                wait_time = (needed / self._rate) if self._rate > 0 else 3600.0
+                    return waited
+                wait_time = (requests_needed - self._available_requests) / self._rate
 
-            await asyncio.sleep(wait_time)
+            self._sleeper(wait_time)
+            waited += wait_time
 
-    async def __aenter__(self):
-        """Async context manager entry point.
-        
-        Acquires 1 request allowance, waiting if necessary.
-        Allows usage like: `async with limiter:`
-        """
-        await self.acquire(1) 
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit point.
-        
-        No action needed for this type of rate limiter (requests are consumed).
-        """
-        pass
-
-    async def get_available_requests(self) -> float: # Return type is float
-         """Returns the approximate current number of available requests as float.
-         
-         Performs a refill check before returning the value for accuracy.
-         Uses the internal lock for consistency.
-         """
-         async with self._lock:
-             self._refill()
-             return self._available_requests 
+    def get_available_requests(self) -> float:
+        """Return the approximate current request allowance."""
+        with self._lock:
+            self._refill()
+            return self._available_requests


### PR DESCRIPTION
## Context

The batch runner previously acquired one rate-limit allowance before processing an entire ARC task. That unit does not map well to provider traffic: a single task can issue several model attempts, an additional model call to parse a response, application-level retries, streaming setup, background-response polling and deletion, or Anthropic batch lifecycle calls. With concurrent tasks, charging once per task allowed bursts that were much higher than the configured request rate and made provider throttling harder to control.

The goal of this change is to make pacing track the outbound operations the benchmark can observe. It is not intended to reproduce every provider quota algorithm or guarantee an exact upper bound on HTTP requests.

## Approach

Move allowance acquisition to a shared adapter request boundary immediately before observable SDK operations. The limiter is thread-safe because provider adapters execute in worker threads, and the same limiter instance is shared by every task for a provider or model-specific limit. This central boundary keeps provider implementations consistent without adding transport-level integrations for every SDK.

Where supported, built-in SDK retries are disabled so application-visible retries pass through the same pacing boundary. Calls for parsing, streaming, background responses, and batch control are also paced.

## Best-effort semantics

Configured rates are operational ballparks, not strict request caps. Actual provider traffic can differ because SDKs may retry internally, agent SDK and CLI sessions can hide multiple model calls behind one invocation, and synchronous work can continue after its await times out. Provider limits should retain headroom and be tuned using throttling responses and provider telemetry.

## Summary

- replace task-level acquisition with observable provider-operation pacing
- share a synchronous, thread-safe token bucket across adapters
- cover model, parsing, retry, streaming, background, and batch-control operations
- divide explicitly configured burst capacity across multi-config workers
- document the best-effort rate-limit contract

## Testing

- uv run python -m pytest -q
- 485 passed