### PR TITLE
Capture Chat Completions reasoning content

### DIFF
--- a/src/arc_agi_benchmarking/adapters/openai_base.py
+++ b/src/arc_agi_benchmarking/adapters/openai_base.py
@@ -81,6 +81,7 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
         cost = self._calculate_cost(response)
         usage = self._get_usage(response)
         reasoning_summary = self._get_reasoning_summary(response)
+        reasoning_content = self._get_reasoning_content(response)
 
         # Convert input messages to choices
         input_choices = [Choice(index=0, message=Message(role="user", content=prompt))]
@@ -104,6 +105,7 @@ class OpenAIBaseAdapter(ProviderAdapter, abc.ABC):
             end_timestamp=end_time,
             choices=all_choices,
             reasoning_summary=reasoning_summary,
+            reasoning_content=reasoning_content,
             kwargs=self.model_config.kwargs,
             usage=usage,
             cost=cost,
@@ -535,6 +537,19 @@ IMPORTANT: Return ONLY the array, with no additional text, quotes, or formatting
                 )  # Will be None if not present
         # Chat Completions API does not currently provide a separate summary field
         return reasoning_summary
+
+    def _get_reasoning_content(self, response: Any) -> Optional[str]:
+        """Extract reasoning content from a Chat Completions response."""
+        if self.model_config.api_type != APIType.CHAT_COMPLETIONS:
+            return None
+
+        choices = getattr(response, "choices", None)
+        if not choices:
+            return None
+
+        message = getattr(choices[0], "message", None)
+        reasoning_content = getattr(message, "reasoning_content", None)
+        return reasoning_content if isinstance(reasoning_content, str) else None
 
     def _get_content(self, response: Any) -> str:
         """

--- a/src/arc_agi_benchmarking/schemas.py
+++ b/src/arc_agi_benchmarking/schemas.py
@@ -130,6 +130,7 @@ class AttemptMetadata(BaseModel):
     end_timestamp: datetime
     choices: List[Choice]
     reasoning_summary: Optional[str] = None
+    reasoning_content: Optional[str] = None
     kwargs: Dict[str, Any]
     usage: Usage
     cost: Cost

--- a/src/arc_agi_benchmarking/tests/test_openai_providers.py
+++ b/src/arc_agi_benchmarking/tests/test_openai_providers.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock, MagicMock, patch
 import inspect # Added for subclass discovery
 import sys # Added for subclass discovery
+from types import SimpleNamespace
 
 from arc_agi_benchmarking.adapters.openai_base import OpenAIBaseAdapter, _filter_api_kwargs
 from arc_agi_benchmarking.adapters.open_ai import OpenAIAdapter
@@ -214,6 +215,24 @@ class TestOpenAIBaseProviderLogic:
         # IMPORTANT: _get_usage itself infers reasoning here when rt_explicit=0 and pt+ct < tt
         assert usage.completion_tokens_details.reasoning_tokens == 20 # inferred rt
 
+    def test_get_reasoning_content(self, adapter_instance):
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(reasoning_content="Full reasoning content")
+                )
+            ]
+        )
+
+        assert adapter_instance._get_reasoning_content(response) == "Full reasoning content"
+
+    def test_get_reasoning_content_returns_none_when_not_set(self, adapter_instance):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace())]
+        )
+
+        assert adapter_instance._get_reasoning_content(response) is None
+
     # --- Test _calculate_cost for different cases ---
     def test_calculate_cost_case_a_no_reasoning(self, adapter_instance, mock_response_case_a_no_reasoning):
         """Test cost calculation for Case A (pt+ct=tt), no explicit reasoning."""
@@ -298,7 +317,8 @@ class TestOpenAIBaseProviderLogic:
         with patch.object(adapter_class, '_call_ai_model') as mock_call_ai, \
              patch.object(adapter_class, '_get_content', return_value='[[1]]') as mock_get_content, \
              patch.object(adapter_class, '_get_role', return_value="assistant") as mock_get_role, \
-             patch.object(adapter_class, '_get_reasoning_summary', return_value="Reasoning summary") as mock_get_reasoning_summary:
+             patch.object(adapter_class, '_get_reasoning_summary', return_value="Reasoning summary") as mock_get_reasoning_summary, \
+             patch.object(adapter_class, '_get_reasoning_content', return_value="Full reasoning content") as mock_get_reasoning_content:
 
             mock_call_ai.return_value = mock_response_case_a_no_reasoning # Use the Case A fixture
             
@@ -317,6 +337,7 @@ class TestOpenAIBaseProviderLogic:
             assert attempt.metadata.usage.completion_tokens == 200 # raw ct
             assert attempt.metadata.usage.total_tokens == 300
             assert attempt.metadata.usage.completion_tokens_details.reasoning_tokens == 0 # rt_explicit
+            assert attempt.metadata.reasoning_content == "Full reasoning content"
             
             # Verify cost calculation based on Case A (no reasoning) logic
             # ct_for_cost = 200, rt_for_cost = 0


### PR DESCRIPTION
## Context

OpenAI-compatible Chat Completions providers can return full reasoning text in choices[0].message.reasoning_content. We observed this with DeepSeek V4 Flash through Baseten: the raw API logs contained reasoning_content, but saved submissions recorded reasoning_summary as null because the adapter only extracts response.reasoning.summary for Responses API calls.

That behavior loses provider-returned reasoning when converting a Chat Completions response into AttemptMetadata. The new field is intentionally separate from reasoning_summary because the provider value is full reasoning content, not a provider-generated summary.

## Changes

- Add an optional reasoning_content field to AttemptMetadata, defaulting to null for backward-compatible loading and providers that do not return it.
- Extract a string-valued choices[0].message.reasoning_content from Chat Completions responses.
- Preserve null when the field is absent, has an unexpected type, or the request uses the Responses API.
- Keep the existing reasoning_summary behavior unchanged.
- Cover populated, absent, and make_prediction wiring cases across OpenAI-compatible adapters.

## Validation

- .venv/bin/python -m pytest -q: 501 passed
- git diff --check
- Re-ran v2 public_eval task 1ae2feb7 with deepseek-v4-flash-0731-low; all six saved attempts contained non-null reasoning_content.